### PR TITLE
fix: improve language switcher contrast

### DIFF
--- a/src/components/FloatingLanguageSwitcher.tsx
+++ b/src/components/FloatingLanguageSwitcher.tsx
@@ -36,7 +36,7 @@ const FloatingLanguageSwitcher: React.FC = () => {
           <Button
             variant='outline'
             size='sm'
-            className='flex items-center gap-2 shadow-lg bg-background/80 backdrop-blur-sm border-border/50 hover:bg-background/90'
+            className='flex items-center gap-2 shadow-lg bg-background border-border/50 hover:bg-muted hover:text-primary'
           >
             <span className='text-lg'>{currentLanguage.flag}</span>
             <span className='hidden sm:inline'>{currentLanguage.name}</span>


### PR DESCRIPTION
## Summary
- ensure floating language switcher has solid background and readable hover text

## Testing
- `npm run lint`
- `npm run test` *(fails: playwright browsers not installed, storybook addon docs missing exports)*

------
https://chatgpt.com/codex/tasks/task_e_68a8289828cc83318cccd6d5be4e6d65