### PR TITLE
fix: upgrade Node.js to 22 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
 
       - name: Validate environment variables and secrets


### PR DESCRIPTION
## Summary

- Upgrades Node.js from `18` to `22` in the GitHub Actions deploy workflow
- Fixes `ReferenceError: crypto is not defined` thrown by `serialize-javascript` (used by `@rollup/plugin-terser`) during the Vite build
- Aligns CI with the project's required runtime version (Node.js 22.16.0 per `AGENTS.md`)

## Root Cause

Older Node.js 18 releases do not expose `crypto` as a global in the CommonJS module context. `serialize-javascript` calls `crypto.randomBytes` at module load time, causing the build to crash after the Vite bundling step completes.