### PR TITLE
fix: add pyarrow to update-data workflow dependencies

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install requests
+          pip install requests pyarrow
 
       - name: Run visitor script
         run: python scripts/fetch_visitors.py


### PR DESCRIPTION
## Summary
- `generate_scores_metadata.py` was switched to use `pyarrow.parquet` on May 15 but `pyarrow` was never added to the workflow's `pip install` step
- This caused the script to fail silently, leaving `scores_metadata.json` stalled at `2026-05-14` and the site showing "Updated: 05/14/2026"
- Adds `pyarrow` to the install step to restore daily metadata updates

## Test plan
- [ ] Merge to main
- [ ] Trigger `Update site data` via `workflow_dispatch` to verify `scores_metadata.json` is updated with the current date
- [ ] Confirm the website shows the correct "Updated" date