### PR TITLE
fix: resolve prettier and lint errors blocking deploy

### DIFF
--- a/e2e/species.spec.ts
+++ b/e2e/species.spec.ts
@@ -8,7 +8,9 @@ test.describe('species page', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/species');
     // Wait for the page to be fully rendered before each test
-    await expect(page.getByRole('heading', { name: /species database/i })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /species database/i })
+    ).toBeVisible();
   });
 
   test('shows the species list', async ({ page }) => {

--- a/e2e/worth-foraging-now.spec.ts
+++ b/e2e/worth-foraging-now.spec.ts
@@ -15,7 +15,12 @@ const MOCK_DATASET = {
     USW: [],
   },
   points: [
-    { regionId: 'NE', lat: 47.6, lng: 7.6, scores: { morel: 9.1, nettle: 8.4, chant: 7.8 } },
+    {
+      regionId: 'NE',
+      lat: 47.6,
+      lng: 7.6,
+      scores: { morel: 9.1, nettle: 8.4, chant: 7.8 },
+    },
   ],
 };
 
@@ -60,7 +65,9 @@ test.describe('worth foraging now page', () => {
     // Wait for loading to disappear
     await expect(page.getByText(/loading/i)).not.toBeVisible({ timeout: 5000 });
     // At least one recommendation card should be present
-    await expect(page.getByText(/why this is worth your time/i).first()).toBeVisible();
+    await expect(
+      page.getByText(/why this is worth your time/i).first()
+    ).toBeVisible();
   });
 
   test('shows the focus selector and allows switching', async ({ page }) => {
@@ -75,7 +82,9 @@ test.describe('worth foraging now page', () => {
     await page.getByRole('option', { name: /mushrooms/i }).click();
 
     // The page should still show recommendations (not crash)
-    await expect(page.getByRole('heading', { name: /worth foraging now/i })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /worth foraging now/i })
+    ).toBeVisible();
   });
 
   test('shows an error state when the data fetch fails', async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,8 +22,10 @@ export default defineConfig({
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     env: {
-      VITE_MAPBOX_ACCESS_TOKEN: process.env.VITE_MAPBOX_ACCESS_TOKEN ?? 'pk.dummy',
-      VITE_MAPBOX_STYLE: process.env.VITE_MAPBOX_STYLE ?? 'mapbox://styles/mapbox/streets-v12',
+      VITE_MAPBOX_ACCESS_TOKEN:
+        process.env.VITE_MAPBOX_ACCESS_TOKEN ?? 'pk.dummy',
+      VITE_MAPBOX_STYLE:
+        process.env.VITE_MAPBOX_STYLE ?? 'mapbox://styles/mapbox/streets-v12',
       VITE_BASE_URL: '/',
       VITE_HOSTNAME: 'http://localhost:3000',
     },

--- a/src/data/support.ts
+++ b/src/data/support.ts
@@ -43,7 +43,8 @@ export const SUPPORT_METHODS: SupportMethod[] = [
     nameKey: 'iota.name',
     descriptionKey: 'iota.description',
     icon: Coins,
-    address: '0x5555a77f863b22f235b6abbeaaf7f7ee8916301ed702401bbeba7a7f756cdea6',
+    address:
+      '0x5555a77f863b22f235b6abbeaaf7f7ee8916301ed702401bbeba7a7f756cdea6',
     type: 'crypto',
     color: '#131f37',
   },

--- a/src/pages/InstructionsPage.tsx
+++ b/src/pages/InstructionsPage.tsx
@@ -339,4 +339,3 @@ export default function InstructionsPage() {
     </>
   );
 }
-

--- a/src/pages/WorthForagingNowPage.tsx
+++ b/src/pages/WorthForagingNowPage.tsx
@@ -19,7 +19,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Loader2, ChefHat, Leaf, MapPinned, ArrowUpRight, Calendar } from 'lucide-react';
+import {
+  Loader2,
+  ChefHat,
+  Leaf,
+  MapPinned,
+  ArrowUpRight,
+  Calendar,
+} from 'lucide-react';
 import { useMapStore } from '@/store/mapStore';
 
 export default function WorthForagingNowPage() {
@@ -73,7 +80,7 @@ export default function WorthForagingNowPage() {
     return () => {
       cancelled = true;
     };
-  }, [center, focus, i18n.language, recipes, species, userLocation]);
+  }, [center, focus, i18n.language, recipes, species, t, userLocation]);
 
   const scopeLabel = useMemo(() => {
     if (!context) return null;
@@ -194,7 +201,9 @@ export default function WorthForagingNowPage() {
                     {t(`worthForagingNow.category.${recommendation.category}`)}
                   </Badge>
                   <Badge className='bg-[#7a1f3d]/10 text-[#7a1f3d] hover:bg-[#7a1f3d]/10'>
-                    {t(`worthForagingNow.confidence.${recommendation.confidence}`)}
+                    {t(
+                      `worthForagingNow.confidence.${recommendation.confidence}`
+                    )}
                   </Badge>
                   <Badge
                     variant='outline'
@@ -211,8 +220,8 @@ export default function WorthForagingNowPage() {
                     {t('worthForagingNow.whyNow')}
                   </div>
                   <ul className='space-y-1.5 border-l-2 border-[#d4c4b0] pl-3 text-sm text-[#5b4c42]'>
-                    {recommendation.whyNow.map((reason, i) => (
-                      <li key={i}>{reason}</li>
+                    {recommendation.whyNow.map(reason => (
+                      <li key={reason}>{reason}</li>
                     ))}
                   </ul>
                 </div>

--- a/src/test/route-to-dish.test.ts
+++ b/src/test/route-to-dish.test.ts
@@ -176,7 +176,11 @@ describe('queryRouteDishData', () => {
     const result = queryRouteDishData({
       map: mapStub as never,
       recipes: [
-        { id: 'salad', title: 'Spring Salad', species: ['garlic', 'dandelion'] },
+        {
+          id: 'salad',
+          title: 'Spring Salad',
+          species: ['garlic', 'dandelion'],
+        },
       ],
       start: [7, 47],
       minScore: 5,

--- a/src/test/worth-foraging-now.test.ts
+++ b/src/test/worth-foraging-now.test.ts
@@ -251,7 +251,9 @@ describe('worth foraging now recommendations', () => {
       userLocation: null,
     });
 
-    expect(result.recommendations.every(r => r.speciesId !== 'hidden')).toBe(true);
+    expect(result.recommendations.every(r => r.speciesId !== 'hidden')).toBe(
+      true
+    );
   });
 
   it('filters by focus category — berries focus excludes mushrooms and plants', () => {
@@ -279,7 +281,9 @@ describe('worth foraging now recommendations', () => {
       userLocation: null,
     });
 
-    expect(result.recommendations.every(r => r.category === 'berry')).toBe(true);
+    expect(result.recommendations.every(r => r.category === 'berry')).toBe(
+      true
+    );
     expect(result.recommendations[0]?.speciesId).toBe('elderberry');
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -217,7 +217,8 @@ export default defineConfig({
           {
             name: 'Worth Foraging Now',
             short_name: 'Now',
-            description: 'See the best nearby foraging targets based on current signals',
+            description:
+              'See the best nearby foraging targets based on current signals',
             url: `worth-foraging-now`,
             icons: [
               {


### PR DESCRIPTION
## Summary
- PR #91 introduced Prettier formatting violations and two ESLint warnings across 9 files, causing the Lint step to fail on every deploy since May 16
- Ran `prettier --write` on all offending files
- Fixed missing `t` dependency in `useEffect` (`react-hooks/exhaustive-deps`)
- Replaced array-index key with stable string key (`react/no-array-index-key`)

## Affected files
- `e2e/worth-foraging-now.spec.ts`
- `e2e/species.spec.ts`
- `playwright.config.ts`
- `src/data/support.ts`
- `src/pages/InstructionsPage.tsx`
- `src/pages/WorthForagingNowPage.tsx`
- `src/test/route-to-dish.test.ts`
- `src/test/worth-foraging-now.test.ts`
- `vite.config.ts`

## Test plan
- [x] Lint passes locally (`npm run lint:check` exits 0)
- [x] Merge unblocks deploys — next push to main should go green