### PR TITLE
fix: Vitest v4 config compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,4 @@
-/// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import { VitePWA } from 'vite-plugin-pwa';


### PR DESCRIPTION
Vitest was bumped to v4 by dependabot (#98), which removed support for the `/// <reference types="vitest" />` triple-slash directive approach. Importing `defineConfig` from `vitest/config` (which re-exports everything from `vite` plus the test types) is the v4-compatible pattern.

Fixes the broken build from the dependabot merge.