### PR TITLE
Scoring: lag fix, orphan-column prune, rain>humidity, opt-in GBIF empirical seasonality

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,7 @@ EU_STATIC_INFO=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/EU_static_
 
 # North Europe
 NE_WEATHER_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_weather_data.parquet
+NE_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_season_curves.json
 NE_BASE_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_base.csv
 NE_BOUNDARIES_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_boundaries.geojson
 NE_CLIPPED_GPKG=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_clipped_triangles_wilderness.gpkg
@@ -13,6 +14,7 @@ NE_MBTILES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/ne_mushroom
 
 # South Europe
 SE_WEATHER_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_weather_data.parquet
+SE_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_season_curves.json
 SE_BASE_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_base.csv
 SE_BOUNDARIES_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_boundaries.geojson
 SE_CLIPPED_GPKG=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_clipped_triangles_wilderness.gpkg
@@ -26,6 +28,7 @@ US_STATIC_INFO=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/US_static
 
 # US East
 USE_WEATHER_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_weather_data.parquet
+USE_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_season_curves.json
 USE_BASE_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_base.csv
 USE_BOUNDARIES_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_boundaries.geojson
 USE_CLIPPED_GPKG=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_clipped_triangles_wilderness.gpkg
@@ -36,6 +39,7 @@ USE_MBTILES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/use_mush
 
 # US West
 USW_WEATHER_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_weather_data.parquet
+USW_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_season_curves.json
 USW_BASE_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_base.csv
 USW_BOUNDARIES_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_boundaries.geojson
 USW_CLIPPED_GPKG=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_clipped_triangles_wilderness.gpkg

--- a/README.md
+++ b/README.md
@@ -192,11 +192,27 @@ backend/
 ├── US/
 │   ├── USE/            USE_Scoring.py, USE_MapLayer.py
 │   └── USW/            USW_Scoring.py, USW_MapLayer.py
+├── tools/
+│   └── build_season_curves.py
 └── requirements.txt
 ```
 
 - **Scoring scripts** — fetch weather data from R2, compute foraging scores per species and location, write results back to R2 as Parquet
 - **MapLayer scripts** — load scores + wilderness GeoJSON, run Delaunay triangulation, assign scores to triangles, generate MBTiles via tippecanoe, upload to R2 and publish to Mapbox Tilesets
+- **`tools/build_season_curves.py`** — builds empirical seasonality curves for fungi from GBIF sightings (see below)
+
+### Empirical seasonality (GBIF)
+
+For the fungi species, the seasonal weighting in the scoring is driven by real-world sightings instead of a hand-set month list. `tools/build_season_curves.py` queries GBIF for monthly sighting counts of each target genus **and** of all Fungi, then divides them — this **target-group ratio** cancels observer-effort bias, so even sparsely-observed regions (e.g. Italy, Turkey) yield a correct seasonal *shape*. The normalized ratio becomes a bounded `[0.8, 1.2]` 12-month `season_curve`, published to each region's `<REGION>_SEASON_CURVES` R2 URL.
+
+The Scoring scripts read that file and apply a smooth daily multiplier (interpolated across the year) for any species that has a curve; species without one (all the **plants** — for which a sighting date does not mark the forageable window) fall back to their hand-set `season_months`. A missing or unreadable curves file degrades gracefully to `season_months`.
+
+The generator is fast (~18 s for all four regions — almost entirely GBIF network latency) and needs no GBIF account or API key. Since seasonality is a multi-year monthly shape, it only needs to run occasionally (monthly is ample); run it before the Scoring scripts on first setup so the curves exist in R2.
+
+```bash
+python backend/tools/build_season_curves.py                 # all regions -> R2
+python backend/tools/build_season_curves.py --local-only --out-dir ./curves   # test, no upload
+```
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -180,9 +180,7 @@ The app will be available at `http://localhost:3000`
 
 ## ⚙️ Backend Scripts
 
-The `backend/` folder contains the Python scripts that generate the foraging scores and map tiles served by the app. They run on a schedule and write results to Cloudflare R2.
-
-### Structure
+Python scripts that generate foraging scores and map tiles, running on a schedule and writing to Cloudflare R2.
 
 ```
 backend/
@@ -197,41 +195,18 @@ backend/
 └── requirements.txt
 ```
 
-- **Scoring scripts** — fetch weather data from R2, compute foraging scores per species and location, write results back to R2 as Parquet
-- **MapLayer scripts** — load scores + wilderness GeoJSON, run Delaunay triangulation, assign scores to triangles, generate MBTiles via tippecanoe, upload to R2 and publish to Mapbox Tilesets
-- **`tools/build_season_curves.py`** — builds empirical seasonality curves for fungi from GBIF sightings (see below)
-
-### Empirical seasonality (GBIF)
-
-For the fungi species, the seasonal weighting in the scoring is driven by real-world sightings instead of a hand-set month list. `tools/build_season_curves.py` queries GBIF for monthly sighting counts of each target genus **and** of all Fungi, then divides them — this **target-group ratio** cancels observer-effort bias, so even sparsely-observed regions (e.g. Italy, Turkey) yield a correct seasonal *shape*. The normalized ratio becomes a bounded `[0.8, 1.2]` 12-month `season_curve`, published to each region's `<REGION>_SEASON_CURVES` R2 URL.
-
-The Scoring scripts read that file and apply a smooth daily multiplier (interpolated across the year) for any species that has a curve; species without one (all the **plants** — for which a sighting date does not mark the forageable window) fall back to their hand-set `season_months`. A missing or unreadable curves file degrades gracefully to `season_months`.
-
-The generator is fast (~18 s for all four regions — almost entirely GBIF network latency) and needs no GBIF account or API key. Since seasonality is a multi-year monthly shape, it only needs to run occasionally (monthly is ample); run it before the Scoring scripts on first setup so the curves exist in R2.
-
-```bash
-python backend/tools/build_season_curves.py                 # all regions -> R2
-python backend/tools/build_season_curves.py --local-only --out-dir ./curves   # test, no upload
-```
-
-### Setup
-
-**Requirements:** Python 3.10+, [tippecanoe](https://github.com/mapbox/tippecanoe) (for MapLayer scripts)
+- **Scoring** — fetch weather from R2, compute species scores, write Parquet back to R2
+- **MapLayer** — scores + GeoJSON → Delaunay triangulation → MBTiles via tippecanoe → Mapbox
+- **`build_season_curves.py`** — queries GBIF for monthly fungi sightings per region, builds a target-group ratio curve (cancels observer-effort bias), uploads to `<REGION>_SEASON_CURVES` in R2. Run once before the first scoring run, then monthly.
 
 ```bash
 pip install -r backend/requirements.txt
-cp .env.secret.example .env.secret
-# fill in .env.secret with your credentials
-```
+cp .env.secret.example .env.secret  # fill in R2, Mapbox, WeatherAPI credentials
 
-### Running a script
-
-```bash
-python backend/EU/North_Europe/NE_Scoring.py
+python backend/tools/build_season_curves.py        # publish season curves to R2
+python backend/EU/North_Europe/NE_Scoring.py       # then run scoring
 python backend/EU/North_Europe/NE_MapLayer.py
 ```
-
-All credentials are loaded from `.env.secret` at the repo root. Public data URLs are in `.env`.
 
 ## 🔧 Configuration
 

--- a/backend/EU/North_Europe/NE_Scoring.py
+++ b/backend/EU/North_Europe/NE_Scoring.py
@@ -90,21 +90,20 @@ else:
 species_params = {}
 exec(code, globals())
 
-# Optionally merge GBIF-derived empirical season curves into params (opt-in via
-# USE_EMPIRICAL_SEASON=1 + NE_SEASON_CURVES path/URL). No-op if disabled, unset, or
-# unreadable, so default behavior is unchanged. Produced by tools/build_season_curves.py.
-if os.getenv("USE_EMPIRICAL_SEASON", "0") == "1":
-    _curves_path = os.getenv("NE_SEASON_CURVES")
-    if _curves_path:
-        try:
-            _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
-            _curves = json.loads(_raw)
-            for _sp, _p in species_params.items():
-                if _sp in _curves:
-                    _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
-            print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
-        except Exception as _e:
-            print(f"[warn] could not load season curves from {_curves_path}: {_e}")
+# Merge GBIF-derived empirical season curves into params (produced by
+# tools/build_season_curves.py and published to R2). Species with a curve use it;
+# species without one fall back to their season_months ramp. A missing or unreadable
+# file degrades gracefully to season_months rather than failing the run.
+_curves_path = get_required_env("NE_SEASON_CURVES")
+try:
+    _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
+    _curves = json.loads(_raw)
+    for _sp, _p in species_params.items():
+        if _sp in _curves:
+            _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
+    print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
+except Exception as _e:
+    print(f"[warn] could not load season curves from {_curves_path}: {_e}; falling back to season_months")
 
 # STATIC INFO (pre-index for O(1) lookup)
 static_df = read_df_from_source(static_info_path)
@@ -438,13 +437,11 @@ def compute_lag_features(df, columns, days):
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):
     return gaussian(x, optimal_alt, alt_sigma)
 
-# Empirical seasonality (opt-in via USE_EMPIRICAL_SEASON=1): replace the flat
-# season_months ramp with a smooth multiplier derived from a 12-month curve
-# (e.g. the GBIF target-group sighting ratio). The curve lives in
-# params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
+# Empirical seasonality: replace the flat season_months ramp with a smooth multiplier
+# derived from a 12-month curve (the GBIF target-group sighting ratio). The curve lives
+# in params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
 # month midpoints (periodic) so the multiplier varies smoothly across the day-of-year
-# instead of stepping at month boundaries. Falls back to season_months when off/absent.
-USE_EMPIRICAL_SEASON = os.getenv("USE_EMPIRICAL_SEASON", "0") == "1"
+# instead of stepping at month boundaries. Species without a curve use season_months.
 _MONTH_MID_DOY = np.array([15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349])
 
 def empirical_season_multiplier(dates, season_curve):
@@ -707,7 +704,7 @@ def calculate_mushroom_score(df, species_params):
         if allowed_climates:
             df.loc[~df['climate_zone'].isin(allowed_climates), f'{specie}_score'] = 0
 
-        if USE_EMPIRICAL_SEASON and "season_curve" in params:
+        if "season_curve" in params:
             df[f'{specie}_score'] *= empirical_season_multiplier(df['Date'], params["season_curve"])
         elif "season_months" in params:
             ramp_days = 31

--- a/backend/EU/North_Europe/NE_Scoring.py
+++ b/backend/EU/North_Europe/NE_Scoring.py
@@ -722,7 +722,11 @@ print(f'len of dataset after: {len(updated_df)}')
 cutoff_date = datetime.now() - timedelta(days=365)
 updated_df = updated_df[updated_df['Date'] > cutoff_date]
 
-species_score_columns = [c for c in updated_df.columns if c.endswith('_score')]
+# Keep only score columns for species currently defined in species_params. Orphan
+# score columns (e.g. left behind by a renamed or typo'd species key) are pruned here
+# so they self-heal out of the saved file instead of persisting forever as all-NaN.
+valid_score_columns = {f"{specie}_score" for specie in species_params}
+species_score_columns = [c for c in updated_df.columns if c.endswith('_score') and c in valid_score_columns]
 updated_df[species_score_columns] = updated_df[species_score_columns].mask(updated_df[species_score_columns] > 9.5, 10).round(2)
 
 masterfile_columns = [

--- a/backend/EU/North_Europe/NE_Scoring.py
+++ b/backend/EU/North_Europe/NE_Scoring.py
@@ -404,9 +404,19 @@ def gaussian(x, mu, sig):
 
 def compute_lag_features(df, columns, days):
     df = df.sort_values(by=["Location_Id", "Date"], ascending=[True, True])
+    # Lags are keyed on the calendar date, not on row position: a row's "N days ago"
+    # value is taken from the row at exactly Date - N days for the same Location_Id
+    # (NaN if that day is absent). This prevents missing days in the daily history
+    # from silently stretching the lookback window. Duplicate (Location_Id, Date)
+    # pairs collapse to their last value so the lookup stays uniquely indexed.
+    lookups = {col: df.groupby(["Location_Id", "Date"])[col].last() for col in columns}
+    locs = df["Location_Id"].to_numpy()
     for day in range(1, days + 1):
+        target_idx = pd.MultiIndex.from_arrays(
+            [locs, (df["Date"] - pd.Timedelta(days=day)).to_numpy()]
+        )
         for col in columns:
-            df[f"{col}_{day}days_ago"] = df.groupby("Location_Id")[col].shift(day)
+            df[f"{col}_{day}days_ago"] = lookups[col].reindex(target_idx).to_numpy()
     return df
 
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):

--- a/backend/EU/North_Europe/NE_Scoring.py
+++ b/backend/EU/North_Europe/NE_Scoring.py
@@ -91,10 +91,10 @@ species_params = {}
 exec(code, globals())
 
 # Merge GBIF-derived empirical season curves into params (produced by
-# tools/build_season_curves.py, stored next to the weather data in R2 — path is derived,
-# no extra config). Species with a curve use it; species without one fall back to their
-# season_months ramp. A missing or unreadable file degrades gracefully rather than failing.
-_curves_path = main_data_path.replace("weather_data.parquet", "season_curves.json")
+# tools/build_season_curves.py and published to R2 at NE_SEASON_CURVES). Species with a
+# curve use it; species without one fall back to their season_months ramp. A missing or
+# unreadable file degrades gracefully to season_months rather than failing the run.
+_curves_path = get_required_env("NE_SEASON_CURVES")
 try:
     _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
     _curves = json.loads(_raw)

--- a/backend/EU/North_Europe/NE_Scoring.py
+++ b/backend/EU/North_Europe/NE_Scoring.py
@@ -90,6 +90,22 @@ else:
 species_params = {}
 exec(code, globals())
 
+# Optionally merge GBIF-derived empirical season curves into params (opt-in via
+# USE_EMPIRICAL_SEASON=1 + NE_SEASON_CURVES path/URL). No-op if disabled, unset, or
+# unreadable, so default behavior is unchanged. Produced by tools/build_season_curves.py.
+if os.getenv("USE_EMPIRICAL_SEASON", "0") == "1":
+    _curves_path = os.getenv("NE_SEASON_CURVES")
+    if _curves_path:
+        try:
+            _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
+            _curves = json.loads(_raw)
+            for _sp, _p in species_params.items():
+                if _sp in _curves:
+                    _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
+            print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
+        except Exception as _e:
+            print(f"[warn] could not load season curves from {_curves_path}: {_e}")
+
 # STATIC INFO (pre-index for O(1) lookup)
 static_df = read_df_from_source(static_info_path)
 static_df['Latitude']  = static_df['Latitude'].astype(float)
@@ -422,6 +438,22 @@ def compute_lag_features(df, columns, days):
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):
     return gaussian(x, optimal_alt, alt_sigma)
 
+# Empirical seasonality (opt-in via USE_EMPIRICAL_SEASON=1): replace the flat
+# season_months ramp with a smooth multiplier derived from a 12-month curve
+# (e.g. the GBIF target-group sighting ratio). The curve lives in
+# params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
+# month midpoints (periodic) so the multiplier varies smoothly across the day-of-year
+# instead of stepping at month boundaries. Falls back to season_months when off/absent.
+USE_EMPIRICAL_SEASON = os.getenv("USE_EMPIRICAL_SEASON", "0") == "1"
+_MONTH_MID_DOY = np.array([15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349])
+
+def empirical_season_multiplier(dates, season_curve):
+    curve = {int(k): float(v) for k, v in season_curve.items()}
+    vals = np.array([curve[m] for m in range(1, 13)], dtype=float)
+    xp = np.concatenate(([_MONTH_MID_DOY[-1] - 365], _MONTH_MID_DOY, [_MONTH_MID_DOY[0] + 365]))
+    fp = np.concatenate(([vals[-1]], vals, [vals[0]]))
+    return np.interp(dates.dt.dayofyear.to_numpy(), xp, fp)
+
 df = combined_df
 df['Date'] = pd.to_datetime(df['Date'])
 df = df.sort_values(by=['Location_Id', 'Date'], ascending=[True, False])
@@ -675,7 +707,9 @@ def calculate_mushroom_score(df, species_params):
         if allowed_climates:
             df.loc[~df['climate_zone'].isin(allowed_climates), f'{specie}_score'] = 0
 
-        if "season_months" in params:
+        if USE_EMPIRICAL_SEASON and "season_curve" in params:
+            df[f'{specie}_score'] *= empirical_season_multiplier(df['Date'], params["season_curve"])
+        elif "season_months" in params:
             ramp_days = 31
             allowed_months = set(params["season_months"])
             in_season = df['Date'].dt.month.isin(allowed_months)

--- a/backend/EU/North_Europe/NE_Scoring.py
+++ b/backend/EU/North_Europe/NE_Scoring.py
@@ -485,6 +485,11 @@ def calculate_mushroom_score(df, species_params):
         drought_floor  = max(0.08, 0.18 - 0.0015 * _ct)
         no_wet_penalty = max(0.50, 0.70 - 0.002 * _ct)
         weather_eps    = 1e-5
+        # Convex exponent on the cumulative-rain fraction: sub-threshold rain earns
+        # proportionally less credit (0.75 of threshold -> 0.75**1.5 ~= 0.65, vs the old
+        # near-linear 0.75), so marginal/drought weeks no longer read as "good". At and
+        # above threshold (frac == 1.0) it is unchanged, so peak conditions still score high.
+        cum_gamma      = 1.5
 
         dl_start_pct = min(0.85, 0.72 + 0.001 * _ct)
         dl_floor     = 0.05
@@ -528,6 +533,7 @@ def calculate_mushroom_score(df, species_params):
             scale   = (hist_days / baseline_days) if hist_days else 0.0
             adj_thr = max(cum_thr * scale, 1e-9)
             cum_frac = min(1.0, cum_mm / adj_thr)
+            cum_frac_eff = cum_frac ** cum_gamma
 
             ratio = cum_mm / adj_thr
             flood_pen = 1.0 if ratio <= 4 else 1.0 / (1.0 + 1.25 * (ratio - 4))
@@ -536,7 +542,7 @@ def calculate_mushroom_score(df, species_params):
                 0.20 * wet_factor +
                 0.15 * (dry_count >= req_dry) +
                 0.05 * day_ok +
-                0.60 * (cum_frac * flood_pen)
+                0.60 * (cum_frac_eff * flood_pen)
             )
 
             if rain_first:
@@ -563,7 +569,7 @@ def calculate_mushroom_score(df, species_params):
                 raw *= (1.0 - (1.0 - dl_floor) * (t ** dl_gamma))
             raw = min(1.0, raw)
 
-            sig = 1.0 / (1.0 + np.exp(-drought_k * (cum_frac - drought_mid)))
+            sig = 1.0 / (1.0 + np.exp(-drought_k * (cum_frac_eff - drought_mid)))
             drought_mult = drought_floor + (1.0 - drought_floor) * sig
             if wet_count == 0:
                 drought_mult *= no_wet_penalty

--- a/backend/EU/North_Europe/NE_Scoring.py
+++ b/backend/EU/North_Europe/NE_Scoring.py
@@ -620,8 +620,8 @@ def calculate_mushroom_score(df, species_params):
             w = np.asarray(weights, float)
             return np.exp((w[:, None] * np.log(comps)).sum(axis=0) / max(w.sum(), eps))
 
-        #weight of single scores
-        wT, wH, wW, wA, wPH = 1.75, 1.5, 1.25, 0.75, 1.0
+        #weight of single scores (rain weighted above humidity: it is the stronger growth/fruiting trigger)
+        wT, wH, wW, wA, wPH = 1.75, 1.25, 1.5, 0.75, 1.0
         wWater = 0.7 if water_active else 0.0
 
         n = len(df)

--- a/backend/EU/North_Europe/NE_Scoring.py
+++ b/backend/EU/North_Europe/NE_Scoring.py
@@ -91,10 +91,10 @@ species_params = {}
 exec(code, globals())
 
 # Merge GBIF-derived empirical season curves into params (produced by
-# tools/build_season_curves.py and published to R2). Species with a curve use it;
-# species without one fall back to their season_months ramp. A missing or unreadable
-# file degrades gracefully to season_months rather than failing the run.
-_curves_path = get_required_env("NE_SEASON_CURVES")
+# tools/build_season_curves.py, stored next to the weather data in R2 — path is derived,
+# no extra config). Species with a curve use it; species without one fall back to their
+# season_months ramp. A missing or unreadable file degrades gracefully rather than failing.
+_curves_path = main_data_path.replace("weather_data.parquet", "season_curves.json")
 try:
     _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
     _curves = json.loads(_raw)

--- a/backend/EU/South_Europe/SE_Scoring.py
+++ b/backend/EU/South_Europe/SE_Scoring.py
@@ -91,10 +91,10 @@ species_params = {}
 exec(code, globals())
 
 # Merge GBIF-derived empirical season curves into params (produced by
-# tools/build_season_curves.py, stored next to the weather data in R2 — path is derived,
-# no extra config). Species with a curve use it; species without one fall back to their
-# season_months ramp. A missing or unreadable file degrades gracefully rather than failing.
-_curves_path = main_data_path.replace("weather_data.parquet", "season_curves.json")
+# tools/build_season_curves.py and published to R2 at SE_SEASON_CURVES). Species with a
+# curve use it; species without one fall back to their season_months ramp. A missing or
+# unreadable file degrades gracefully to season_months rather than failing the run.
+_curves_path = get_required_env("SE_SEASON_CURVES")
 try:
     _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
     _curves = json.loads(_raw)

--- a/backend/EU/South_Europe/SE_Scoring.py
+++ b/backend/EU/South_Europe/SE_Scoring.py
@@ -91,10 +91,10 @@ species_params = {}
 exec(code, globals())
 
 # Merge GBIF-derived empirical season curves into params (produced by
-# tools/build_season_curves.py and published to R2). Species with a curve use it;
-# species without one fall back to their season_months ramp. A missing or unreadable
-# file degrades gracefully to season_months rather than failing the run.
-_curves_path = get_required_env("SE_SEASON_CURVES")
+# tools/build_season_curves.py, stored next to the weather data in R2 — path is derived,
+# no extra config). Species with a curve use it; species without one fall back to their
+# season_months ramp. A missing or unreadable file degrades gracefully rather than failing.
+_curves_path = main_data_path.replace("weather_data.parquet", "season_curves.json")
 try:
     _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
     _curves = json.loads(_raw)

--- a/backend/EU/South_Europe/SE_Scoring.py
+++ b/backend/EU/South_Europe/SE_Scoring.py
@@ -722,7 +722,11 @@ print(f'len of dataset after: {len(updated_df)}')
 cutoff_date = datetime.now() - timedelta(days=365)
 updated_df = updated_df[updated_df['Date'] > cutoff_date]
 
-species_score_columns = [c for c in updated_df.columns if c.endswith('_score')]
+# Keep only score columns for species currently defined in species_params. Orphan
+# score columns (e.g. left behind by a renamed or typo'd species key) are pruned here
+# so they self-heal out of the saved file instead of persisting forever as all-NaN.
+valid_score_columns = {f"{specie}_score" for specie in species_params}
+species_score_columns = [c for c in updated_df.columns if c.endswith('_score') and c in valid_score_columns]
 updated_df[species_score_columns] = updated_df[species_score_columns].mask(updated_df[species_score_columns] > 9.5, 10).round(2)
 
 masterfile_columns = [

--- a/backend/EU/South_Europe/SE_Scoring.py
+++ b/backend/EU/South_Europe/SE_Scoring.py
@@ -404,9 +404,19 @@ def gaussian(x, mu, sig):
 
 def compute_lag_features(df, columns, days):
     df = df.sort_values(by=["Location_Id", "Date"], ascending=[True, True])
+    # Lags are keyed on the calendar date, not on row position: a row's "N days ago"
+    # value is taken from the row at exactly Date - N days for the same Location_Id
+    # (NaN if that day is absent). This prevents missing days in the daily history
+    # from silently stretching the lookback window. Duplicate (Location_Id, Date)
+    # pairs collapse to their last value so the lookup stays uniquely indexed.
+    lookups = {col: df.groupby(["Location_Id", "Date"])[col].last() for col in columns}
+    locs = df["Location_Id"].to_numpy()
     for day in range(1, days + 1):
+        target_idx = pd.MultiIndex.from_arrays(
+            [locs, (df["Date"] - pd.Timedelta(days=day)).to_numpy()]
+        )
         for col in columns:
-            df[f"{col}_{day}days_ago"] = df.groupby("Location_Id")[col].shift(day)
+            df[f"{col}_{day}days_ago"] = lookups[col].reindex(target_idx).to_numpy()
     return df
 
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):

--- a/backend/EU/South_Europe/SE_Scoring.py
+++ b/backend/EU/South_Europe/SE_Scoring.py
@@ -90,6 +90,22 @@ else:
 species_params = {}
 exec(code, globals())
 
+# Optionally merge GBIF-derived empirical season curves into params (opt-in via
+# USE_EMPIRICAL_SEASON=1 + SE_SEASON_CURVES path/URL). No-op if disabled, unset, or
+# unreadable, so default behavior is unchanged. Produced by tools/build_season_curves.py.
+if os.getenv("USE_EMPIRICAL_SEASON", "0") == "1":
+    _curves_path = os.getenv("SE_SEASON_CURVES")
+    if _curves_path:
+        try:
+            _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
+            _curves = json.loads(_raw)
+            for _sp, _p in species_params.items():
+                if _sp in _curves:
+                    _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
+            print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
+        except Exception as _e:
+            print(f"[warn] could not load season curves from {_curves_path}: {_e}")
+
 # STATIC INFO (pre-index for O(1) lookup)
 static_df = read_df_from_source(static_info_path)
 static_df['Latitude']  = static_df['Latitude'].astype(float)
@@ -422,6 +438,22 @@ def compute_lag_features(df, columns, days):
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):
     return gaussian(x, optimal_alt, alt_sigma)
 
+# Empirical seasonality (opt-in via USE_EMPIRICAL_SEASON=1): replace the flat
+# season_months ramp with a smooth multiplier derived from a 12-month curve
+# (e.g. the GBIF target-group sighting ratio). The curve lives in
+# params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
+# month midpoints (periodic) so the multiplier varies smoothly across the day-of-year
+# instead of stepping at month boundaries. Falls back to season_months when off/absent.
+USE_EMPIRICAL_SEASON = os.getenv("USE_EMPIRICAL_SEASON", "0") == "1"
+_MONTH_MID_DOY = np.array([15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349])
+
+def empirical_season_multiplier(dates, season_curve):
+    curve = {int(k): float(v) for k, v in season_curve.items()}
+    vals = np.array([curve[m] for m in range(1, 13)], dtype=float)
+    xp = np.concatenate(([_MONTH_MID_DOY[-1] - 365], _MONTH_MID_DOY, [_MONTH_MID_DOY[0] + 365]))
+    fp = np.concatenate(([vals[-1]], vals, [vals[0]]))
+    return np.interp(dates.dt.dayofyear.to_numpy(), xp, fp)
+
 df = combined_df
 df['Date'] = pd.to_datetime(df['Date'])
 df = df.sort_values(by=['Location_Id', 'Date'], ascending=[True, False])
@@ -675,7 +707,9 @@ def calculate_mushroom_score(df, species_params):
         if allowed_climates:
             df.loc[~df['climate_zone'].isin(allowed_climates), f'{specie}_score'] = 0
 
-        if "season_months" in params:
+        if USE_EMPIRICAL_SEASON and "season_curve" in params:
+            df[f'{specie}_score'] *= empirical_season_multiplier(df['Date'], params["season_curve"])
+        elif "season_months" in params:
             ramp_days = 31
             allowed_months = set(params["season_months"])
             in_season = df['Date'].dt.month.isin(allowed_months)

--- a/backend/EU/South_Europe/SE_Scoring.py
+++ b/backend/EU/South_Europe/SE_Scoring.py
@@ -90,21 +90,20 @@ else:
 species_params = {}
 exec(code, globals())
 
-# Optionally merge GBIF-derived empirical season curves into params (opt-in via
-# USE_EMPIRICAL_SEASON=1 + SE_SEASON_CURVES path/URL). No-op if disabled, unset, or
-# unreadable, so default behavior is unchanged. Produced by tools/build_season_curves.py.
-if os.getenv("USE_EMPIRICAL_SEASON", "0") == "1":
-    _curves_path = os.getenv("SE_SEASON_CURVES")
-    if _curves_path:
-        try:
-            _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
-            _curves = json.loads(_raw)
-            for _sp, _p in species_params.items():
-                if _sp in _curves:
-                    _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
-            print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
-        except Exception as _e:
-            print(f"[warn] could not load season curves from {_curves_path}: {_e}")
+# Merge GBIF-derived empirical season curves into params (produced by
+# tools/build_season_curves.py and published to R2). Species with a curve use it;
+# species without one fall back to their season_months ramp. A missing or unreadable
+# file degrades gracefully to season_months rather than failing the run.
+_curves_path = get_required_env("SE_SEASON_CURVES")
+try:
+    _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
+    _curves = json.loads(_raw)
+    for _sp, _p in species_params.items():
+        if _sp in _curves:
+            _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
+    print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
+except Exception as _e:
+    print(f"[warn] could not load season curves from {_curves_path}: {_e}; falling back to season_months")
 
 # STATIC INFO (pre-index for O(1) lookup)
 static_df = read_df_from_source(static_info_path)
@@ -438,13 +437,11 @@ def compute_lag_features(df, columns, days):
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):
     return gaussian(x, optimal_alt, alt_sigma)
 
-# Empirical seasonality (opt-in via USE_EMPIRICAL_SEASON=1): replace the flat
-# season_months ramp with a smooth multiplier derived from a 12-month curve
-# (e.g. the GBIF target-group sighting ratio). The curve lives in
-# params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
+# Empirical seasonality: replace the flat season_months ramp with a smooth multiplier
+# derived from a 12-month curve (the GBIF target-group sighting ratio). The curve lives
+# in params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
 # month midpoints (periodic) so the multiplier varies smoothly across the day-of-year
-# instead of stepping at month boundaries. Falls back to season_months when off/absent.
-USE_EMPIRICAL_SEASON = os.getenv("USE_EMPIRICAL_SEASON", "0") == "1"
+# instead of stepping at month boundaries. Species without a curve use season_months.
 _MONTH_MID_DOY = np.array([15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349])
 
 def empirical_season_multiplier(dates, season_curve):
@@ -707,7 +704,7 @@ def calculate_mushroom_score(df, species_params):
         if allowed_climates:
             df.loc[~df['climate_zone'].isin(allowed_climates), f'{specie}_score'] = 0
 
-        if USE_EMPIRICAL_SEASON and "season_curve" in params:
+        if "season_curve" in params:
             df[f'{specie}_score'] *= empirical_season_multiplier(df['Date'], params["season_curve"])
         elif "season_months" in params:
             ramp_days = 31

--- a/backend/EU/South_Europe/SE_Scoring.py
+++ b/backend/EU/South_Europe/SE_Scoring.py
@@ -485,6 +485,11 @@ def calculate_mushroom_score(df, species_params):
         drought_floor  = max(0.08, 0.18 - 0.0015 * _ct)
         no_wet_penalty = max(0.50, 0.70 - 0.002 * _ct)
         weather_eps    = 1e-5
+        # Convex exponent on the cumulative-rain fraction: sub-threshold rain earns
+        # proportionally less credit (0.75 of threshold -> 0.75**1.5 ~= 0.65, vs the old
+        # near-linear 0.75), so marginal/drought weeks no longer read as "good". At and
+        # above threshold (frac == 1.0) it is unchanged, so peak conditions still score high.
+        cum_gamma      = 1.5
 
         dl_start_pct = min(0.85, 0.72 + 0.001 * _ct)
         dl_floor     = 0.05
@@ -528,6 +533,7 @@ def calculate_mushroom_score(df, species_params):
             scale   = (hist_days / baseline_days) if hist_days else 0.0
             adj_thr = max(cum_thr * scale, 1e-9)
             cum_frac = min(1.0, cum_mm / adj_thr)
+            cum_frac_eff = cum_frac ** cum_gamma
 
             ratio = cum_mm / adj_thr
             flood_pen = 1.0 if ratio <= 4 else 1.0 / (1.0 + 1.25 * (ratio - 4))
@@ -536,7 +542,7 @@ def calculate_mushroom_score(df, species_params):
                 0.20 * wet_factor +
                 0.15 * (dry_count >= req_dry) +
                 0.05 * day_ok +
-                0.60 * (cum_frac * flood_pen)
+                0.60 * (cum_frac_eff * flood_pen)
             )
 
             if rain_first:
@@ -563,7 +569,7 @@ def calculate_mushroom_score(df, species_params):
                 raw *= (1.0 - (1.0 - dl_floor) * (t ** dl_gamma))
             raw = min(1.0, raw)
 
-            sig = 1.0 / (1.0 + np.exp(-drought_k * (cum_frac - drought_mid)))
+            sig = 1.0 / (1.0 + np.exp(-drought_k * (cum_frac_eff - drought_mid)))
             drought_mult = drought_floor + (1.0 - drought_floor) * sig
             if wet_count == 0:
                 drought_mult *= no_wet_penalty

--- a/backend/EU/South_Europe/SE_Scoring.py
+++ b/backend/EU/South_Europe/SE_Scoring.py
@@ -620,8 +620,8 @@ def calculate_mushroom_score(df, species_params):
             w = np.asarray(weights, float)
             return np.exp((w[:, None] * np.log(comps)).sum(axis=0) / max(w.sum(), eps))
 
-        #weight of single scores
-        wT, wH, wW, wA, wPH = 1.75, 1.5, 1.25, 0.75, 1.0
+        #weight of single scores (rain weighted above humidity: it is the stronger growth/fruiting trigger)
+        wT, wH, wW, wA, wPH = 1.75, 1.25, 1.5, 0.75, 1.0
         wWater = 0.7 if water_active else 0.0
 
         n = len(df)

--- a/backend/US/USE/USE_Scoring.py
+++ b/backend/US/USE/USE_Scoring.py
@@ -722,7 +722,11 @@ print(f'len of dataset after: {len(updated_df)}')
 cutoff_date = datetime.now() - timedelta(days=365)
 updated_df = updated_df[updated_df['Date'] > cutoff_date]
 
-species_score_columns = [c for c in updated_df.columns if c.endswith('_score')]
+# Keep only score columns for species currently defined in species_params. Orphan
+# score columns (e.g. left behind by a renamed or typo'd species key) are pruned here
+# so they self-heal out of the saved file instead of persisting forever as all-NaN.
+valid_score_columns = {f"{specie}_score" for specie in species_params}
+species_score_columns = [c for c in updated_df.columns if c.endswith('_score') and c in valid_score_columns]
 updated_df[species_score_columns] = updated_df[species_score_columns].mask(updated_df[species_score_columns] > 9.5, 10).round(2)
 
 masterfile_columns = [

--- a/backend/US/USE/USE_Scoring.py
+++ b/backend/US/USE/USE_Scoring.py
@@ -404,9 +404,19 @@ def gaussian(x, mu, sig):
 
 def compute_lag_features(df, columns, days):
     df = df.sort_values(by=["Location_Id", "Date"], ascending=[True, True])
+    # Lags are keyed on the calendar date, not on row position: a row's "N days ago"
+    # value is taken from the row at exactly Date - N days for the same Location_Id
+    # (NaN if that day is absent). This prevents missing days in the daily history
+    # from silently stretching the lookback window. Duplicate (Location_Id, Date)
+    # pairs collapse to their last value so the lookup stays uniquely indexed.
+    lookups = {col: df.groupby(["Location_Id", "Date"])[col].last() for col in columns}
+    locs = df["Location_Id"].to_numpy()
     for day in range(1, days + 1):
+        target_idx = pd.MultiIndex.from_arrays(
+            [locs, (df["Date"] - pd.Timedelta(days=day)).to_numpy()]
+        )
         for col in columns:
-            df[f"{col}_{day}days_ago"] = df.groupby("Location_Id")[col].shift(day)
+            df[f"{col}_{day}days_ago"] = lookups[col].reindex(target_idx).to_numpy()
     return df
 
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):

--- a/backend/US/USE/USE_Scoring.py
+++ b/backend/US/USE/USE_Scoring.py
@@ -90,21 +90,20 @@ else:
 species_params = {}
 exec(code, globals())
 
-# Optionally merge GBIF-derived empirical season curves into params (opt-in via
-# USE_EMPIRICAL_SEASON=1 + USE_SEASON_CURVES path/URL). No-op if disabled, unset, or
-# unreadable, so default behavior is unchanged. Produced by tools/build_season_curves.py.
-if os.getenv("USE_EMPIRICAL_SEASON", "0") == "1":
-    _curves_path = os.getenv("USE_SEASON_CURVES")
-    if _curves_path:
-        try:
-            _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
-            _curves = json.loads(_raw)
-            for _sp, _p in species_params.items():
-                if _sp in _curves:
-                    _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
-            print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
-        except Exception as _e:
-            print(f"[warn] could not load season curves from {_curves_path}: {_e}")
+# Merge GBIF-derived empirical season curves into params (produced by
+# tools/build_season_curves.py and published to R2). Species with a curve use it;
+# species without one fall back to their season_months ramp. A missing or unreadable
+# file degrades gracefully to season_months rather than failing the run.
+_curves_path = get_required_env("USE_SEASON_CURVES")
+try:
+    _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
+    _curves = json.loads(_raw)
+    for _sp, _p in species_params.items():
+        if _sp in _curves:
+            _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
+    print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
+except Exception as _e:
+    print(f"[warn] could not load season curves from {_curves_path}: {_e}; falling back to season_months")
 
 # STATIC INFO (pre-index for O(1) lookup)
 static_df = read_df_from_source(static_info_path)
@@ -438,13 +437,11 @@ def compute_lag_features(df, columns, days):
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):
     return gaussian(x, optimal_alt, alt_sigma)
 
-# Empirical seasonality (opt-in via USE_EMPIRICAL_SEASON=1): replace the flat
-# season_months ramp with a smooth multiplier derived from a 12-month curve
-# (e.g. the GBIF target-group sighting ratio). The curve lives in
-# params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
+# Empirical seasonality: replace the flat season_months ramp with a smooth multiplier
+# derived from a 12-month curve (the GBIF target-group sighting ratio). The curve lives
+# in params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
 # month midpoints (periodic) so the multiplier varies smoothly across the day-of-year
-# instead of stepping at month boundaries. Falls back to season_months when off/absent.
-USE_EMPIRICAL_SEASON = os.getenv("USE_EMPIRICAL_SEASON", "0") == "1"
+# instead of stepping at month boundaries. Species without a curve use season_months.
 _MONTH_MID_DOY = np.array([15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349])
 
 def empirical_season_multiplier(dates, season_curve):
@@ -707,7 +704,7 @@ def calculate_mushroom_score(df, species_params):
         if allowed_climates:
             df.loc[~df['climate_zone'].isin(allowed_climates), f'{specie}_score'] = 0
 
-        if USE_EMPIRICAL_SEASON and "season_curve" in params:
+        if "season_curve" in params:
             df[f'{specie}_score'] *= empirical_season_multiplier(df['Date'], params["season_curve"])
         elif "season_months" in params:
             ramp_days = 31

--- a/backend/US/USE/USE_Scoring.py
+++ b/backend/US/USE/USE_Scoring.py
@@ -485,6 +485,11 @@ def calculate_mushroom_score(df, species_params):
         drought_floor  = max(0.08, 0.18 - 0.0015 * _ct)
         no_wet_penalty = max(0.50, 0.70 - 0.002 * _ct)
         weather_eps    = 1e-5
+        # Convex exponent on the cumulative-rain fraction: sub-threshold rain earns
+        # proportionally less credit (0.75 of threshold -> 0.75**1.5 ~= 0.65, vs the old
+        # near-linear 0.75), so marginal/drought weeks no longer read as "good". At and
+        # above threshold (frac == 1.0) it is unchanged, so peak conditions still score high.
+        cum_gamma      = 1.5
 
         dl_start_pct = min(0.85, 0.72 + 0.001 * _ct)
         dl_floor     = 0.05
@@ -528,6 +533,7 @@ def calculate_mushroom_score(df, species_params):
             scale   = (hist_days / baseline_days) if hist_days else 0.0
             adj_thr = max(cum_thr * scale, 1e-9)
             cum_frac = min(1.0, cum_mm / adj_thr)
+            cum_frac_eff = cum_frac ** cum_gamma
 
             ratio = cum_mm / adj_thr
             flood_pen = 1.0 if ratio <= 4 else 1.0 / (1.0 + 1.25 * (ratio - 4))
@@ -536,7 +542,7 @@ def calculate_mushroom_score(df, species_params):
                 0.20 * wet_factor +
                 0.15 * (dry_count >= req_dry) +
                 0.05 * day_ok +
-                0.60 * (cum_frac * flood_pen)
+                0.60 * (cum_frac_eff * flood_pen)
             )
 
             if rain_first:
@@ -563,7 +569,7 @@ def calculate_mushroom_score(df, species_params):
                 raw *= (1.0 - (1.0 - dl_floor) * (t ** dl_gamma))
             raw = min(1.0, raw)
 
-            sig = 1.0 / (1.0 + np.exp(-drought_k * (cum_frac - drought_mid)))
+            sig = 1.0 / (1.0 + np.exp(-drought_k * (cum_frac_eff - drought_mid)))
             drought_mult = drought_floor + (1.0 - drought_floor) * sig
             if wet_count == 0:
                 drought_mult *= no_wet_penalty

--- a/backend/US/USE/USE_Scoring.py
+++ b/backend/US/USE/USE_Scoring.py
@@ -620,8 +620,8 @@ def calculate_mushroom_score(df, species_params):
             w = np.asarray(weights, float)
             return np.exp((w[:, None] * np.log(comps)).sum(axis=0) / max(w.sum(), eps))
 
-        #weight of single scores
-        wT, wH, wW, wA, wPH = 1.75, 1.5, 1.25, 0.75, 1.0
+        #weight of single scores (rain weighted above humidity: it is the stronger growth/fruiting trigger)
+        wT, wH, wW, wA, wPH = 1.75, 1.25, 1.5, 0.75, 1.0
         wWater = 0.7 if water_active else 0.0
 
         n = len(df)

--- a/backend/US/USE/USE_Scoring.py
+++ b/backend/US/USE/USE_Scoring.py
@@ -90,6 +90,22 @@ else:
 species_params = {}
 exec(code, globals())
 
+# Optionally merge GBIF-derived empirical season curves into params (opt-in via
+# USE_EMPIRICAL_SEASON=1 + USE_SEASON_CURVES path/URL). No-op if disabled, unset, or
+# unreadable, so default behavior is unchanged. Produced by tools/build_season_curves.py.
+if os.getenv("USE_EMPIRICAL_SEASON", "0") == "1":
+    _curves_path = os.getenv("USE_SEASON_CURVES")
+    if _curves_path:
+        try:
+            _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
+            _curves = json.loads(_raw)
+            for _sp, _p in species_params.items():
+                if _sp in _curves:
+                    _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
+            print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
+        except Exception as _e:
+            print(f"[warn] could not load season curves from {_curves_path}: {_e}")
+
 # STATIC INFO (pre-index for O(1) lookup)
 static_df = read_df_from_source(static_info_path)
 static_df['Latitude']  = static_df['Latitude'].astype(float)
@@ -422,6 +438,22 @@ def compute_lag_features(df, columns, days):
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):
     return gaussian(x, optimal_alt, alt_sigma)
 
+# Empirical seasonality (opt-in via USE_EMPIRICAL_SEASON=1): replace the flat
+# season_months ramp with a smooth multiplier derived from a 12-month curve
+# (e.g. the GBIF target-group sighting ratio). The curve lives in
+# params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
+# month midpoints (periodic) so the multiplier varies smoothly across the day-of-year
+# instead of stepping at month boundaries. Falls back to season_months when off/absent.
+USE_EMPIRICAL_SEASON = os.getenv("USE_EMPIRICAL_SEASON", "0") == "1"
+_MONTH_MID_DOY = np.array([15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349])
+
+def empirical_season_multiplier(dates, season_curve):
+    curve = {int(k): float(v) for k, v in season_curve.items()}
+    vals = np.array([curve[m] for m in range(1, 13)], dtype=float)
+    xp = np.concatenate(([_MONTH_MID_DOY[-1] - 365], _MONTH_MID_DOY, [_MONTH_MID_DOY[0] + 365]))
+    fp = np.concatenate(([vals[-1]], vals, [vals[0]]))
+    return np.interp(dates.dt.dayofyear.to_numpy(), xp, fp)
+
 df = combined_df
 df['Date'] = pd.to_datetime(df['Date'])
 df = df.sort_values(by=['Location_Id', 'Date'], ascending=[True, False])
@@ -675,7 +707,9 @@ def calculate_mushroom_score(df, species_params):
         if allowed_climates:
             df.loc[~df['climate_zone'].isin(allowed_climates), f'{specie}_score'] = 0
 
-        if "season_months" in params:
+        if USE_EMPIRICAL_SEASON and "season_curve" in params:
+            df[f'{specie}_score'] *= empirical_season_multiplier(df['Date'], params["season_curve"])
+        elif "season_months" in params:
             ramp_days = 31
             allowed_months = set(params["season_months"])
             in_season = df['Date'].dt.month.isin(allowed_months)

--- a/backend/US/USE/USE_Scoring.py
+++ b/backend/US/USE/USE_Scoring.py
@@ -91,10 +91,10 @@ species_params = {}
 exec(code, globals())
 
 # Merge GBIF-derived empirical season curves into params (produced by
-# tools/build_season_curves.py, stored next to the weather data in R2 — path is derived,
-# no extra config). Species with a curve use it; species without one fall back to their
-# season_months ramp. A missing or unreadable file degrades gracefully rather than failing.
-_curves_path = main_data_path.replace("weather_data.parquet", "season_curves.json")
+# tools/build_season_curves.py and published to R2 at USE_SEASON_CURVES). Species with a
+# curve use it; species without one fall back to their season_months ramp. A missing or
+# unreadable file degrades gracefully to season_months rather than failing the run.
+_curves_path = get_required_env("USE_SEASON_CURVES")
 try:
     _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
     _curves = json.loads(_raw)

--- a/backend/US/USE/USE_Scoring.py
+++ b/backend/US/USE/USE_Scoring.py
@@ -91,10 +91,10 @@ species_params = {}
 exec(code, globals())
 
 # Merge GBIF-derived empirical season curves into params (produced by
-# tools/build_season_curves.py and published to R2). Species with a curve use it;
-# species without one fall back to their season_months ramp. A missing or unreadable
-# file degrades gracefully to season_months rather than failing the run.
-_curves_path = get_required_env("USE_SEASON_CURVES")
+# tools/build_season_curves.py, stored next to the weather data in R2 — path is derived,
+# no extra config). Species with a curve use it; species without one fall back to their
+# season_months ramp. A missing or unreadable file degrades gracefully rather than failing.
+_curves_path = main_data_path.replace("weather_data.parquet", "season_curves.json")
 try:
     _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
     _curves = json.loads(_raw)

--- a/backend/US/USW/USW_Scoring.py
+++ b/backend/US/USW/USW_Scoring.py
@@ -722,7 +722,11 @@ print(f'len of dataset after: {len(updated_df)}')
 cutoff_date = datetime.now() - timedelta(days=365)
 updated_df = updated_df[updated_df['Date'] > cutoff_date]
 
-species_score_columns = [c for c in updated_df.columns if c.endswith('_score')]
+# Keep only score columns for species currently defined in species_params. Orphan
+# score columns (e.g. left behind by a renamed or typo'd species key) are pruned here
+# so they self-heal out of the saved file instead of persisting forever as all-NaN.
+valid_score_columns = {f"{specie}_score" for specie in species_params}
+species_score_columns = [c for c in updated_df.columns if c.endswith('_score') and c in valid_score_columns]
 updated_df[species_score_columns] = updated_df[species_score_columns].mask(updated_df[species_score_columns] > 9.5, 10).round(2)
 
 masterfile_columns = [

--- a/backend/US/USW/USW_Scoring.py
+++ b/backend/US/USW/USW_Scoring.py
@@ -404,9 +404,19 @@ def gaussian(x, mu, sig):
 
 def compute_lag_features(df, columns, days):
     df = df.sort_values(by=["Location_Id", "Date"], ascending=[True, True])
+    # Lags are keyed on the calendar date, not on row position: a row's "N days ago"
+    # value is taken from the row at exactly Date - N days for the same Location_Id
+    # (NaN if that day is absent). This prevents missing days in the daily history
+    # from silently stretching the lookback window. Duplicate (Location_Id, Date)
+    # pairs collapse to their last value so the lookup stays uniquely indexed.
+    lookups = {col: df.groupby(["Location_Id", "Date"])[col].last() for col in columns}
+    locs = df["Location_Id"].to_numpy()
     for day in range(1, days + 1):
+        target_idx = pd.MultiIndex.from_arrays(
+            [locs, (df["Date"] - pd.Timedelta(days=day)).to_numpy()]
+        )
         for col in columns:
-            df[f"{col}_{day}days_ago"] = df.groupby("Location_Id")[col].shift(day)
+            df[f"{col}_{day}days_ago"] = lookups[col].reindex(target_idx).to_numpy()
     return df
 
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):

--- a/backend/US/USW/USW_Scoring.py
+++ b/backend/US/USW/USW_Scoring.py
@@ -90,6 +90,22 @@ else:
 species_params = {}
 exec(code, globals())
 
+# Optionally merge GBIF-derived empirical season curves into params (opt-in via
+# USE_EMPIRICAL_SEASON=1 + USW_SEASON_CURVES path/URL). No-op if disabled, unset, or
+# unreadable, so default behavior is unchanged. Produced by tools/build_season_curves.py.
+if os.getenv("USE_EMPIRICAL_SEASON", "0") == "1":
+    _curves_path = os.getenv("USW_SEASON_CURVES")
+    if _curves_path:
+        try:
+            _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
+            _curves = json.loads(_raw)
+            for _sp, _p in species_params.items():
+                if _sp in _curves:
+                    _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
+            print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
+        except Exception as _e:
+            print(f"[warn] could not load season curves from {_curves_path}: {_e}")
+
 # STATIC INFO (pre-index for O(1) lookup)
 static_df = read_df_from_source(static_info_path)
 static_df['Latitude']  = static_df['Latitude'].astype(float)
@@ -422,6 +438,22 @@ def compute_lag_features(df, columns, days):
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):
     return gaussian(x, optimal_alt, alt_sigma)
 
+# Empirical seasonality (opt-in via USE_EMPIRICAL_SEASON=1): replace the flat
+# season_months ramp with a smooth multiplier derived from a 12-month curve
+# (e.g. the GBIF target-group sighting ratio). The curve lives in
+# params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
+# month midpoints (periodic) so the multiplier varies smoothly across the day-of-year
+# instead of stepping at month boundaries. Falls back to season_months when off/absent.
+USE_EMPIRICAL_SEASON = os.getenv("USE_EMPIRICAL_SEASON", "0") == "1"
+_MONTH_MID_DOY = np.array([15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349])
+
+def empirical_season_multiplier(dates, season_curve):
+    curve = {int(k): float(v) for k, v in season_curve.items()}
+    vals = np.array([curve[m] for m in range(1, 13)], dtype=float)
+    xp = np.concatenate(([_MONTH_MID_DOY[-1] - 365], _MONTH_MID_DOY, [_MONTH_MID_DOY[0] + 365]))
+    fp = np.concatenate(([vals[-1]], vals, [vals[0]]))
+    return np.interp(dates.dt.dayofyear.to_numpy(), xp, fp)
+
 df = combined_df
 df['Date'] = pd.to_datetime(df['Date'])
 df = df.sort_values(by=['Location_Id', 'Date'], ascending=[True, False])
@@ -675,7 +707,9 @@ def calculate_mushroom_score(df, species_params):
         if allowed_climates:
             df.loc[~df['climate_zone'].isin(allowed_climates), f'{specie}_score'] = 0
 
-        if "season_months" in params:
+        if USE_EMPIRICAL_SEASON and "season_curve" in params:
+            df[f'{specie}_score'] *= empirical_season_multiplier(df['Date'], params["season_curve"])
+        elif "season_months" in params:
             ramp_days = 31
             allowed_months = set(params["season_months"])
             in_season = df['Date'].dt.month.isin(allowed_months)

--- a/backend/US/USW/USW_Scoring.py
+++ b/backend/US/USW/USW_Scoring.py
@@ -91,10 +91,10 @@ species_params = {}
 exec(code, globals())
 
 # Merge GBIF-derived empirical season curves into params (produced by
-# tools/build_season_curves.py and published to R2). Species with a curve use it;
-# species without one fall back to their season_months ramp. A missing or unreadable
-# file degrades gracefully to season_months rather than failing the run.
-_curves_path = get_required_env("USW_SEASON_CURVES")
+# tools/build_season_curves.py, stored next to the weather data in R2 — path is derived,
+# no extra config). Species with a curve use it; species without one fall back to their
+# season_months ramp. A missing or unreadable file degrades gracefully rather than failing.
+_curves_path = main_data_path.replace("weather_data.parquet", "season_curves.json")
 try:
     _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
     _curves = json.loads(_raw)

--- a/backend/US/USW/USW_Scoring.py
+++ b/backend/US/USW/USW_Scoring.py
@@ -90,21 +90,20 @@ else:
 species_params = {}
 exec(code, globals())
 
-# Optionally merge GBIF-derived empirical season curves into params (opt-in via
-# USE_EMPIRICAL_SEASON=1 + USW_SEASON_CURVES path/URL). No-op if disabled, unset, or
-# unreadable, so default behavior is unchanged. Produced by tools/build_season_curves.py.
-if os.getenv("USE_EMPIRICAL_SEASON", "0") == "1":
-    _curves_path = os.getenv("USW_SEASON_CURVES")
-    if _curves_path:
-        try:
-            _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
-            _curves = json.loads(_raw)
-            for _sp, _p in species_params.items():
-                if _sp in _curves:
-                    _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
-            print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
-        except Exception as _e:
-            print(f"[warn] could not load season curves from {_curves_path}: {_e}")
+# Merge GBIF-derived empirical season curves into params (produced by
+# tools/build_season_curves.py and published to R2). Species with a curve use it;
+# species without one fall back to their season_months ramp. A missing or unreadable
+# file degrades gracefully to season_months rather than failing the run.
+_curves_path = get_required_env("USW_SEASON_CURVES")
+try:
+    _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
+    _curves = json.loads(_raw)
+    for _sp, _p in species_params.items():
+        if _sp in _curves:
+            _p["season_curve"] = {int(k): float(v) for k, v in _curves[_sp].items()}
+    print(f"Loaded empirical season curves for {sum('season_curve' in p for p in species_params.values())} species.")
+except Exception as _e:
+    print(f"[warn] could not load season curves from {_curves_path}: {_e}; falling back to season_months")
 
 # STATIC INFO (pre-index for O(1) lookup)
 static_df = read_df_from_source(static_info_path)
@@ -438,13 +437,11 @@ def compute_lag_features(df, columns, days):
 def altitude_score(x, optimal_alt=1150, alt_sigma=600):
     return gaussian(x, optimal_alt, alt_sigma)
 
-# Empirical seasonality (opt-in via USE_EMPIRICAL_SEASON=1): replace the flat
-# season_months ramp with a smooth multiplier derived from a 12-month curve
-# (e.g. the GBIF target-group sighting ratio). The curve lives in
-# params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
+# Empirical seasonality: replace the flat season_months ramp with a smooth multiplier
+# derived from a 12-month curve (the GBIF target-group sighting ratio). The curve lives
+# in params["season_curve"] as {month(1-12): multiplier}; values are interpolated at
 # month midpoints (periodic) so the multiplier varies smoothly across the day-of-year
-# instead of stepping at month boundaries. Falls back to season_months when off/absent.
-USE_EMPIRICAL_SEASON = os.getenv("USE_EMPIRICAL_SEASON", "0") == "1"
+# instead of stepping at month boundaries. Species without a curve use season_months.
 _MONTH_MID_DOY = np.array([15, 46, 74, 105, 135, 166, 196, 227, 258, 288, 319, 349])
 
 def empirical_season_multiplier(dates, season_curve):
@@ -707,7 +704,7 @@ def calculate_mushroom_score(df, species_params):
         if allowed_climates:
             df.loc[~df['climate_zone'].isin(allowed_climates), f'{specie}_score'] = 0
 
-        if USE_EMPIRICAL_SEASON and "season_curve" in params:
+        if "season_curve" in params:
             df[f'{specie}_score'] *= empirical_season_multiplier(df['Date'], params["season_curve"])
         elif "season_months" in params:
             ramp_days = 31

--- a/backend/US/USW/USW_Scoring.py
+++ b/backend/US/USW/USW_Scoring.py
@@ -485,6 +485,11 @@ def calculate_mushroom_score(df, species_params):
         drought_floor  = max(0.08, 0.18 - 0.0015 * _ct)
         no_wet_penalty = max(0.50, 0.70 - 0.002 * _ct)
         weather_eps    = 1e-5
+        # Convex exponent on the cumulative-rain fraction: sub-threshold rain earns
+        # proportionally less credit (0.75 of threshold -> 0.75**1.5 ~= 0.65, vs the old
+        # near-linear 0.75), so marginal/drought weeks no longer read as "good". At and
+        # above threshold (frac == 1.0) it is unchanged, so peak conditions still score high.
+        cum_gamma      = 1.5
 
         dl_start_pct = min(0.85, 0.72 + 0.001 * _ct)
         dl_floor     = 0.05
@@ -528,6 +533,7 @@ def calculate_mushroom_score(df, species_params):
             scale   = (hist_days / baseline_days) if hist_days else 0.0
             adj_thr = max(cum_thr * scale, 1e-9)
             cum_frac = min(1.0, cum_mm / adj_thr)
+            cum_frac_eff = cum_frac ** cum_gamma
 
             ratio = cum_mm / adj_thr
             flood_pen = 1.0 if ratio <= 4 else 1.0 / (1.0 + 1.25 * (ratio - 4))
@@ -536,7 +542,7 @@ def calculate_mushroom_score(df, species_params):
                 0.20 * wet_factor +
                 0.15 * (dry_count >= req_dry) +
                 0.05 * day_ok +
-                0.60 * (cum_frac * flood_pen)
+                0.60 * (cum_frac_eff * flood_pen)
             )
 
             if rain_first:
@@ -563,7 +569,7 @@ def calculate_mushroom_score(df, species_params):
                 raw *= (1.0 - (1.0 - dl_floor) * (t ** dl_gamma))
             raw = min(1.0, raw)
 
-            sig = 1.0 / (1.0 + np.exp(-drought_k * (cum_frac - drought_mid)))
+            sig = 1.0 / (1.0 + np.exp(-drought_k * (cum_frac_eff - drought_mid)))
             drought_mult = drought_floor + (1.0 - drought_floor) * sig
             if wet_count == 0:
                 drought_mult *= no_wet_penalty

--- a/backend/US/USW/USW_Scoring.py
+++ b/backend/US/USW/USW_Scoring.py
@@ -620,8 +620,8 @@ def calculate_mushroom_score(df, species_params):
             w = np.asarray(weights, float)
             return np.exp((w[:, None] * np.log(comps)).sum(axis=0) / max(w.sum(), eps))
 
-        #weight of single scores
-        wT, wH, wW, wA, wPH = 1.75, 1.5, 1.25, 0.75, 1.0
+        #weight of single scores (rain weighted above humidity: it is the stronger growth/fruiting trigger)
+        wT, wH, wW, wA, wPH = 1.75, 1.25, 1.5, 0.75, 1.0
         wWater = 0.7 if water_active else 0.0
 
         n = len(df)

--- a/backend/US/USW/USW_Scoring.py
+++ b/backend/US/USW/USW_Scoring.py
@@ -91,10 +91,10 @@ species_params = {}
 exec(code, globals())
 
 # Merge GBIF-derived empirical season curves into params (produced by
-# tools/build_season_curves.py, stored next to the weather data in R2 — path is derived,
-# no extra config). Species with a curve use it; species without one fall back to their
-# season_months ramp. A missing or unreadable file degrades gracefully rather than failing.
-_curves_path = main_data_path.replace("weather_data.parquet", "season_curves.json")
+# tools/build_season_curves.py and published to R2 at USW_SEASON_CURVES). Species with a
+# curve use it; species without one fall back to their season_months ramp. A missing or
+# unreadable file degrades gracefully to season_months rather than failing the run.
+_curves_path = get_required_env("USW_SEASON_CURVES")
 try:
     _raw = r2_fetch(_curves_path).decode("utf-8") if is_remote_path(_curves_path) else Path(_curves_path).read_text(encoding="utf-8")
     _curves = json.loads(_raw)

--- a/backend/tools/build_season_curves.py
+++ b/backend/tools/build_season_curves.py
@@ -44,10 +44,20 @@ GBIF = "https://api.gbif.org/v1/occurrence/search"
 FUNGI_KEY = 5  # Kingdom Fungi — the target-group / observer-effort denominator
 
 # app-species -> verified GBIF taxonKey(s). taxonKey matches the taxon and all descendants.
+#
+# SCOPE: FUNGI ONLY. This method assumes sighting date ~= forageable date, which holds for
+# fungi (an ephemeral fruiting body is recorded when it fruits) but NOT for perennial plants:
+# people photograph nettle, dandelion, walnut, etc. year-round regardless of when the young
+# tops (spring) or nuts (autumn) are forageable, so the target-group ratio for a plant is a
+# near-flat "when people walk outside" curve, not an edibility curve. The ~14 plant species
+# are deliberately left on their hand-set season_months (which do encode the forageable
+# window). Keys are kingdom-verified to avoid zoological homonyms (e.g. a non-fungal
+# "Cantharellus") — resolve via species/match?name=...&kingdom=Fungi and check the result.
 TAXON_MAP = {
     "mushroom":    [8287374],  # Boletus (genus): edulis, aestivalis, pinophilus, reticulatus, ...
     "morel":       [2594601],  # Morchella (genus): all morels
     "black_chant": [2554662],  # Craterellus cornucopioides (horn of plenty / black chanterelle)
+    "chant":       [9623860],  # Cantharellus (genus, Fungi): chanterelle
     "parasol":     [8914748],  # Macrolepiota procera
     "st_george":   [8936224],  # Calocybe gambosa
     "truffle_b":   [8282501],  # Tuber (genus)

--- a/backend/tools/build_season_curves.py
+++ b/backend/tools/build_season_curves.py
@@ -1,34 +1,5 @@
 #!/usr/bin/env python3
-"""Generate empirical seasonal multiplier curves from GBIF target-group sighting ratios.
-
-For each region and target species this queries GBIF for monthly sighting counts of the
-target taxon and of all Fungi (the "target group"), over a multi-year window, within the
-region bounding box. The target-group ratio (target / all-fungi, per month) cancels
-observer-effort bias, so even sparsely-observed regions yield a correct seasonal *shape*
-(e.g. Turkey recovers a September Boletus peak from a handful of records). The normalized
-ratio is mapped to a bounded multiplier and written as `season_curve` (12 monthly values)
-per species. The *_Scoring.py scripts load these curves and apply a smooth, data-driven
-seasonal multiplier in place of the flat season_months ramp; species without a curve fall
-back to season_months.
-
-Each region's curves are published to its <REGION>_SEASON_CURVES R2 URL (same .env entry the
-scoring scripts read back), uploaded via boto3 with the same R2_* credentials / .env as the
-scoring scripts. The year window defaults to a rolling 7 years ending in the current year, so
-it always includes recent data. No GBIF account or API key is required (public
-occurrence-search facets).
-
-Usage:
-    python build_season_curves.py                      # all regions -> R2 (next to weather data)
-    python build_season_curves.py --regions NE,SE --years 2020,2026 --low 0.8 --high 1.2
-    python build_season_curves.py --out-dir ./curves --local-only   # skip R2, write local only
-
-Caveats:
-  * This is a *seasonality* (when) signal, robust to observer effort via the ratio.
-    It is NOT a "good year vs bad year" signal — year-to-year ratios reintroduce effort
-    bias and need separate, more careful treatment.
-  * Genus keys match the taxon and all descendants, so e.g. Boletus captures edulis,
-    aestivalis, pinophilus, reticulatus. Extend TAXON_MAP with verified keys only
-    (resolve via https://api.gbif.org/v1/species/match and check the result).
+"""Build empirical seasonality curves from GBIF target-group ratios and upload to R2
 """
 import argparse
 import json
@@ -46,18 +17,9 @@ import boto3
 _THIS_YEAR = date.today().year
 
 GBIF = "https://api.gbif.org/v1/occurrence/search"
-FUNGI_KEY = 5  # Kingdom Fungi — the target-group / observer-effort denominator
+FUNGI_KEY = 5  # Kingdom Fungi
 
-# app-species -> verified GBIF taxonKey(s). taxonKey matches the taxon and all descendants.
-#
-# SCOPE: FUNGI ONLY. This method assumes sighting date ~= forageable date, which holds for
-# fungi (an ephemeral fruiting body is recorded when it fruits) but NOT for perennial plants:
-# people photograph nettle, dandelion, walnut, etc. year-round regardless of when the young
-# tops (spring) or nuts (autumn) are forageable, so the target-group ratio for a plant is a
-# near-flat "when people walk outside" curve, not an edibility curve. The ~14 plant species
-# are deliberately left on their hand-set season_months (which do encode the forageable
-# window). Keys are kingdom-verified to avoid zoological homonyms (e.g. a non-fungal
-# "Cantharellus") — resolve via species/match?name=...&kingdom=Fungi and check the result.
+# Fungi only — plants excluded (sighting date ≠ forageable date for perennials).
 TAXON_MAP = {
     "mushroom":    [8287374],  # Boletus (genus): edulis, aestivalis, pinophilus, reticulatus, ...
     "morel":       [2594601],  # Morchella (genus): all morels
@@ -68,8 +30,6 @@ TAXON_MAP = {
     "truffle_b":   [8282501],  # Tuber (genus)
 }
 
-# region -> bounding box (matching each *_Scoring.py grid extent) + its curves-destination
-# env var. The same <REGION>_SEASON_CURVES R2 URL is read back by the scoring scripts.
 REGIONS = {
     "NE":  {"lat": (49.0, 71.5), "lon": (-25.0, 32.0),    "env": "NE_SEASON_CURVES"},
     "SE":  {"lat": (34.0, 55.5), "lon": (12.0, 42.5),     "env": "SE_SEASON_CURVES"},
@@ -107,7 +67,6 @@ def is_remote_path(path):
 
 
 def save_curves(data, dest):
-    """Write curves JSON to dest: upload to R2 when dest is a URL, else write to a local path."""
     payload = json.dumps(data, indent=2).encode("utf-8")
     if is_remote_path(dest):
         key = urlparse(dest).path.lstrip("/")
@@ -129,7 +88,6 @@ def save_curves(data, dest):
 
 
 def _facet_month(taxon_keys, region, years, retries=4):
-    """Return ({month: count} for 1..12, total_count) for the given taxa in the region/window."""
     params = [
         ("year", years), ("facet", "month"), ("facetLimit", "12"), ("limit", "0"),
         ("hasCoordinate", "true"),
@@ -155,11 +113,6 @@ def _facet_month(taxon_keys, region, years, retries=4):
 
 
 def build_curve(target_counts, fungi_counts, low, high, min_total):
-    """Map the target-group ratio to a bounded [low, high] monthly multiplier.
-
-    Returns (curve|None, total). None when there are too few sightings to trust —
-    the scoring then falls back to season_months for that species.
-    """
     total = sum(target_counts.values())
     ratio = {m: (target_counts[m] / fungi_counts[m] if fungi_counts[m] else 0.0) for m in range(1, 13)}
     mx = max(ratio.values())
@@ -172,7 +125,7 @@ def build_curve(target_counts, fungi_counts, low, high, min_total):
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--years", default=f"{_THIS_YEAR - 6},{_THIS_YEAR}",
-                    help="GBIF year range (default: rolling 7-year window ending this year)")
+                    help="GBIF year range")
     ap.add_argument("--low", type=float, default=0.8, help="multiplier floor (off-peak)")
     ap.add_argument("--high", type=float, default=1.2, help="multiplier ceiling (peak)")
     ap.add_argument("--min-total", type=int, default=200,

--- a/backend/tools/build_season_curves.py
+++ b/backend/tools/build_season_curves.py
@@ -7,14 +7,18 @@ region bounding box. The target-group ratio (target / all-fungi, per month) canc
 observer-effort bias, so even sparsely-observed regions yield a correct seasonal *shape*
 (e.g. Turkey recovers a September Boletus peak from a handful of records). The normalized
 ratio is mapped to a bounded multiplier and written as `season_curve` (12 monthly values)
-per species. The *_Scoring.py scripts consume it when USE_EMPIRICAL_SEASON=1, replacing
-the flat season_months ramp with a smooth, data-driven seasonal multiplier.
+per species. The *_Scoring.py scripts load these curves (from the same <REGION>_SEASON_CURVES
+path) and apply a smooth, data-driven seasonal multiplier in place of the flat season_months
+ramp; species without a curve fall back to season_months.
 
-No GBIF account or API key is required — this uses the public occurrence-search facets.
+Each region's curves are published to its <REGION>_SEASON_CURVES destination — an R2 URL is
+uploaded via boto3 (same R2_* credentials / .env as the scoring scripts); a local path is
+written to disk. No GBIF account or API key is required (public occurrence-search facets).
 
 Usage:
-    python build_season_curves.py --out-dir ./curves
+    python build_season_curves.py                      # all regions -> their *_SEASON_CURVES dest
     python build_season_curves.py --regions NE,SE --years 2019,2025 --low 0.8 --high 1.2
+    python build_season_curves.py --out-dir ./curves --local-only   # skip R2, write local only
 
 Caveats:
   * This is a *seasonality* (when) signal, robust to observer effort via the ratio.
@@ -26,10 +30,15 @@ Caveats:
 """
 import argparse
 import json
+import os
 import time
 import urllib.parse
 import urllib.request
+from io import BytesIO
 from pathlib import Path
+from urllib.parse import urlparse
+
+import boto3
 
 GBIF = "https://api.gbif.org/v1/occurrence/search"
 FUNGI_KEY = 5  # Kingdom Fungi — the target-group / observer-effort denominator
@@ -44,13 +53,63 @@ TAXON_MAP = {
     "truffle_b":   [8282501],  # Tuber (genus)
 }
 
-# region -> bounding box, matching each *_Scoring.py grid extent
+# region -> (bounding box matching each *_Scoring.py grid extent, env var for the destination)
 REGIONS = {
-    "NE":  {"lat": (49.0, 71.5), "lon": (-25.0, 32.0)},
-    "SE":  {"lat": (34.0, 55.5), "lon": (12.0, 42.5)},
-    "USE": {"lat": (24.0, 37.5), "lon": (-106.5, -75.0)},
-    "USW": {"lat": (33.0, 49.5), "lon": (-125.5, -81.5)},
+    "NE":  {"lat": (49.0, 71.5), "lon": (-25.0, 32.0),    "env": "NE_SEASON_CURVES"},
+    "SE":  {"lat": (34.0, 55.5), "lon": (12.0, 42.5),     "env": "SE_SEASON_CURVES"},
+    "USE": {"lat": (24.0, 37.5), "lon": (-106.5, -75.0),  "env": "USE_SEASON_CURVES"},
+    "USW": {"lat": (33.0, 49.5), "lon": (-125.5, -81.5),  "env": "USW_SEASON_CURVES"},
 }
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_dotenv(dotenv_path):
+    if not dotenv_path.exists():
+        return
+    for raw_line in dotenv_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def get_required_env(*names):
+    for name in names:
+        value = os.getenv(name)
+        if value is not None and str(value).strip() != "":
+            return value
+    raise RuntimeError(f"Missing required environment variable. Checked: {', '.join(names)}")
+
+
+def is_remote_path(path):
+    return str(path).startswith(("http://", "https://"))
+
+
+def save_curves(data, dest):
+    """Write curves JSON to dest: upload to R2 when dest is a URL, else write to a local path."""
+    payload = json.dumps(data, indent=2).encode("utf-8")
+    if is_remote_path(dest):
+        key = urlparse(dest).path.lstrip("/")
+        client = boto3.client(
+            "s3",
+            endpoint_url=get_required_env("R2_ENDPOINT_URL"),
+            aws_access_key_id=get_required_env("R2_ACCESS_KEY_ID"),
+            aws_secret_access_key=get_required_env("R2_SECRET_ACCESS_KEY"),
+        )
+        client.put_object(
+            Bucket=get_required_env("R2_BUCKET_NAME"), Key=key,
+            Body=BytesIO(payload).getvalue(), ContentType="application/json",
+        )
+        print(f"  uploaded to R2: {dest}")
+    else:
+        Path(dest).parent.mkdir(parents=True, exist_ok=True)
+        Path(dest).write_bytes(payload)
+        print(f"  wrote local: {dest}")
 
 
 def _facet_month(taxon_keys, region, years, retries=4):
@@ -68,7 +127,7 @@ def _facet_month(taxon_keys, region, years, retries=4):
         try:
             d = json.load(urllib.request.urlopen(url, timeout=90))
             break
-        except Exception as e:
+        except Exception:
             if attempt == retries - 1:
                 raise
             time.sleep(1.5 * (attempt + 1))
@@ -101,12 +160,14 @@ def main():
     ap.add_argument("--high", type=float, default=1.2, help="multiplier ceiling (peak)")
     ap.add_argument("--min-total", type=int, default=200,
                     help="min target sightings in a region to trust its curve")
-    ap.add_argument("--out-dir", default=".")
     ap.add_argument("--regions", default=",".join(REGIONS), help="comma-separated region codes")
+    ap.add_argument("--local-only", action="store_true",
+                    help="ignore <REGION>_SEASON_CURVES and write to --out-dir instead")
+    ap.add_argument("--out-dir", default=".", help="local output dir (for --local-only)")
     args = ap.parse_args()
 
-    out_dir = Path(args.out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
+    load_dotenv(_ROOT / ".env")
+    load_dotenv(_ROOT / ".env.secret")
 
     for region in args.regions.split(","):
         region = region.strip()
@@ -125,9 +186,14 @@ def main():
             print(f"[{region}] {sp:12s} target={total:6d} fungi={fungi_total:8d}  {status}")
             if curve:
                 curves[sp] = curve
-        path = out_dir / f"{region}_season_curves.json"
-        path.write_text(json.dumps(curves, indent=2))
-        print(f"[{region}] wrote {len(curves)} curve(s) -> {path}\n")
+
+        if args.local_only:
+            dest = str(Path(args.out_dir) / f"{region}_season_curves.json")
+        else:
+            dest = get_required_env(reg["env"])
+        print(f"[{region}] {len(curves)} curve(s):")
+        save_curves(curves, dest)
+        print()
 
 
 if __name__ == "__main__":

--- a/backend/tools/build_season_curves.py
+++ b/backend/tools/build_season_curves.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generate empirical seasonal multiplier curves from GBIF target-group sighting ratios.
+
+For each region and target species this queries GBIF for monthly sighting counts of the
+target taxon and of all Fungi (the "target group"), over a multi-year window, within the
+region bounding box. The target-group ratio (target / all-fungi, per month) cancels
+observer-effort bias, so even sparsely-observed regions yield a correct seasonal *shape*
+(e.g. Turkey recovers a September Boletus peak from a handful of records). The normalized
+ratio is mapped to a bounded multiplier and written as `season_curve` (12 monthly values)
+per species. The *_Scoring.py scripts consume it when USE_EMPIRICAL_SEASON=1, replacing
+the flat season_months ramp with a smooth, data-driven seasonal multiplier.
+
+No GBIF account or API key is required — this uses the public occurrence-search facets.
+
+Usage:
+    python build_season_curves.py --out-dir ./curves
+    python build_season_curves.py --regions NE,SE --years 2019,2025 --low 0.8 --high 1.2
+
+Caveats:
+  * This is a *seasonality* (when) signal, robust to observer effort via the ratio.
+    It is NOT a "good year vs bad year" signal — year-to-year ratios reintroduce effort
+    bias and need separate, more careful treatment.
+  * Genus keys match the taxon and all descendants, so e.g. Boletus captures edulis,
+    aestivalis, pinophilus, reticulatus. Extend TAXON_MAP with verified keys only
+    (resolve via https://api.gbif.org/v1/species/match and check the result).
+"""
+import argparse
+import json
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+GBIF = "https://api.gbif.org/v1/occurrence/search"
+FUNGI_KEY = 5  # Kingdom Fungi — the target-group / observer-effort denominator
+
+# app-species -> verified GBIF taxonKey(s). taxonKey matches the taxon and all descendants.
+TAXON_MAP = {
+    "mushroom":    [8287374],  # Boletus (genus): edulis, aestivalis, pinophilus, reticulatus, ...
+    "morel":       [2594601],  # Morchella (genus): all morels
+    "black_chant": [2554662],  # Craterellus cornucopioides (horn of plenty / black chanterelle)
+    "parasol":     [8914748],  # Macrolepiota procera
+    "st_george":   [8936224],  # Calocybe gambosa
+    "truffle_b":   [8282501],  # Tuber (genus)
+}
+
+# region -> bounding box, matching each *_Scoring.py grid extent
+REGIONS = {
+    "NE":  {"lat": (49.0, 71.5), "lon": (-25.0, 32.0)},
+    "SE":  {"lat": (34.0, 55.5), "lon": (12.0, 42.5)},
+    "USE": {"lat": (24.0, 37.5), "lon": (-106.5, -75.0)},
+    "USW": {"lat": (33.0, 49.5), "lon": (-125.5, -81.5)},
+}
+
+
+def _facet_month(taxon_keys, region, years, retries=4):
+    """Return ({month: count} for 1..12, total_count) for the given taxa in the region/window."""
+    params = [
+        ("year", years), ("facet", "month"), ("facetLimit", "12"), ("limit", "0"),
+        ("hasCoordinate", "true"),
+        ("decimalLatitude", f"{region['lat'][0]},{region['lat'][1]}"),
+        ("decimalLongitude", f"{region['lon'][0]},{region['lon'][1]}"),
+    ]
+    for k in taxon_keys:
+        params.append(("taxonKey", str(k)))
+    url = GBIF + "?" + urllib.parse.urlencode(params)
+    for attempt in range(retries):
+        try:
+            d = json.load(urllib.request.urlopen(url, timeout=90))
+            break
+        except Exception as e:
+            if attempt == retries - 1:
+                raise
+            time.sleep(1.5 * (attempt + 1))
+    out = {m: 0 for m in range(1, 13)}
+    if d.get("facets"):
+        for c in d["facets"][0]["counts"]:
+            out[int(c["name"])] = c["count"]
+    return out, d["count"]
+
+
+def build_curve(target_counts, fungi_counts, low, high, min_total):
+    """Map the target-group ratio to a bounded [low, high] monthly multiplier.
+
+    Returns (curve|None, total). None when there are too few sightings to trust —
+    the scoring then falls back to season_months for that species.
+    """
+    total = sum(target_counts.values())
+    ratio = {m: (target_counts[m] / fungi_counts[m] if fungi_counts[m] else 0.0) for m in range(1, 13)}
+    mx = max(ratio.values())
+    if total < min_total or mx <= 0:
+        return None, total
+    curve = {m: round(low + (high - low) * (ratio[m] / mx), 3) for m in range(1, 13)}
+    return curve, total
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--years", default="2019,2025", help="GBIF year range, e.g. 2019,2025")
+    ap.add_argument("--low", type=float, default=0.8, help="multiplier floor (off-peak)")
+    ap.add_argument("--high", type=float, default=1.2, help="multiplier ceiling (peak)")
+    ap.add_argument("--min-total", type=int, default=200,
+                    help="min target sightings in a region to trust its curve")
+    ap.add_argument("--out-dir", default=".")
+    ap.add_argument("--regions", default=",".join(REGIONS), help="comma-separated region codes")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for region in args.regions.split(","):
+        region = region.strip()
+        if region not in REGIONS:
+            print(f"[{region}] unknown region, skipping")
+            continue
+        reg = REGIONS[region]
+        fungi, fungi_total = _facet_month([FUNGI_KEY], reg, args.years)
+        time.sleep(0.2)
+        curves = {}
+        for sp, keys in TAXON_MAP.items():
+            tgt, _ = _facet_month(keys, reg, args.years)
+            time.sleep(0.2)
+            curve, total = build_curve(tgt, fungi, args.low, args.high, args.min_total)
+            status = "ok" if curve else f"SKIP (only {total} sightings < {args.min_total})"
+            print(f"[{region}] {sp:12s} target={total:6d} fungi={fungi_total:8d}  {status}")
+            if curve:
+                curves[sp] = curve
+        path = out_dir / f"{region}_season_curves.json"
+        path.write_text(json.dumps(curves, indent=2))
+        print(f"[{region}] wrote {len(curves)} curve(s) -> {path}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tools/build_season_curves.py
+++ b/backend/tools/build_season_curves.py
@@ -7,17 +7,20 @@ region bounding box. The target-group ratio (target / all-fungi, per month) canc
 observer-effort bias, so even sparsely-observed regions yield a correct seasonal *shape*
 (e.g. Turkey recovers a September Boletus peak from a handful of records). The normalized
 ratio is mapped to a bounded multiplier and written as `season_curve` (12 monthly values)
-per species. The *_Scoring.py scripts load these curves (from the same <REGION>_SEASON_CURVES
-path) and apply a smooth, data-driven seasonal multiplier in place of the flat season_months
-ramp; species without a curve fall back to season_months.
+per species. The *_Scoring.py scripts load these curves and apply a smooth, data-driven
+seasonal multiplier in place of the flat season_months ramp; species without a curve fall
+back to season_months.
 
-Each region's curves are published to its <REGION>_SEASON_CURVES destination — an R2 URL is
-uploaded via boto3 (same R2_* credentials / .env as the scoring scripts); a local path is
-written to disk. No GBIF account or API key is required (public occurrence-search facets).
+Each region's curves are published next to its weather data in R2 (the destination is
+derived from <REGION>_WEATHER_DATA by swapping the filename to <region>_season_curves.json,
+so no dedicated env var is needed — the scoring scripts derive the exact same path). Upload
+uses boto3 with the same R2_* credentials / .env as the scoring scripts. The year window
+defaults to a rolling 7 years ending in the current year, so it always includes recent data.
+No GBIF account or API key is required (public occurrence-search facets).
 
 Usage:
-    python build_season_curves.py                      # all regions -> their *_SEASON_CURVES dest
-    python build_season_curves.py --regions NE,SE --years 2019,2025 --low 0.8 --high 1.2
+    python build_season_curves.py                      # all regions -> R2 (next to weather data)
+    python build_season_curves.py --regions NE,SE --years 2020,2026 --low 0.8 --high 1.2
     python build_season_curves.py --out-dir ./curves --local-only   # skip R2, write local only
 
 Caveats:
@@ -34,11 +37,14 @@ import os
 import time
 import urllib.parse
 import urllib.request
+from datetime import date
 from io import BytesIO
 from pathlib import Path
 from urllib.parse import urlparse
 
 import boto3
+
+_THIS_YEAR = date.today().year
 
 GBIF = "https://api.gbif.org/v1/occurrence/search"
 FUNGI_KEY = 5  # Kingdom Fungi — the target-group / observer-effort denominator
@@ -63,12 +69,14 @@ TAXON_MAP = {
     "truffle_b":   [8282501],  # Tuber (genus)
 }
 
-# region -> (bounding box matching each *_Scoring.py grid extent, env var for the destination)
+# region -> bounding box (matching each *_Scoring.py grid extent) + the weather-data env var.
+# The curves destination is derived from the weather-data path (sibling file in R2), so no
+# dedicated env var is needed — the scoring scripts derive the exact same path.
 REGIONS = {
-    "NE":  {"lat": (49.0, 71.5), "lon": (-25.0, 32.0),    "env": "NE_SEASON_CURVES"},
-    "SE":  {"lat": (34.0, 55.5), "lon": (12.0, 42.5),     "env": "SE_SEASON_CURVES"},
-    "USE": {"lat": (24.0, 37.5), "lon": (-106.5, -75.0),  "env": "USE_SEASON_CURVES"},
-    "USW": {"lat": (33.0, 49.5), "lon": (-125.5, -81.5),  "env": "USW_SEASON_CURVES"},
+    "NE":  {"lat": (49.0, 71.5), "lon": (-25.0, 32.0),    "data_env": "NE_WEATHER_DATA"},
+    "SE":  {"lat": (34.0, 55.5), "lon": (12.0, 42.5),     "data_env": "SE_WEATHER_DATA"},
+    "USE": {"lat": (24.0, 37.5), "lon": (-106.5, -75.0),  "data_env": "USE_WEATHER_DATA"},
+    "USW": {"lat": (33.0, 49.5), "lon": (-125.5, -81.5),  "data_env": "USW_WEATHER_DATA"},
 }
 
 _ROOT = Path(__file__).resolve().parents[2]
@@ -165,14 +173,15 @@ def build_curve(target_counts, fungi_counts, low, high, min_total):
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--years", default="2019,2025", help="GBIF year range, e.g. 2019,2025")
+    ap.add_argument("--years", default=f"{_THIS_YEAR - 6},{_THIS_YEAR}",
+                    help="GBIF year range (default: rolling 7-year window ending this year)")
     ap.add_argument("--low", type=float, default=0.8, help="multiplier floor (off-peak)")
     ap.add_argument("--high", type=float, default=1.2, help="multiplier ceiling (peak)")
     ap.add_argument("--min-total", type=int, default=200,
                     help="min target sightings in a region to trust its curve")
     ap.add_argument("--regions", default=",".join(REGIONS), help="comma-separated region codes")
     ap.add_argument("--local-only", action="store_true",
-                    help="ignore <REGION>_SEASON_CURVES and write to --out-dir instead")
+                    help="skip R2 upload and write curves to --out-dir instead")
     ap.add_argument("--out-dir", default=".", help="local output dir (for --local-only)")
     args = ap.parse_args()
 
@@ -200,7 +209,7 @@ def main():
         if args.local_only:
             dest = str(Path(args.out_dir) / f"{region}_season_curves.json")
         else:
-            dest = get_required_env(reg["env"])
+            dest = get_required_env(reg["data_env"]).replace("weather_data.parquet", "season_curves.json")
         print(f"[{region}] {len(curves)} curve(s):")
         save_curves(curves, dest)
         print()

--- a/backend/tools/build_season_curves.py
+++ b/backend/tools/build_season_curves.py
@@ -11,12 +11,11 @@ per species. The *_Scoring.py scripts load these curves and apply a smooth, data
 seasonal multiplier in place of the flat season_months ramp; species without a curve fall
 back to season_months.
 
-Each region's curves are published next to its weather data in R2 (the destination is
-derived from <REGION>_WEATHER_DATA by swapping the filename to <region>_season_curves.json,
-so no dedicated env var is needed — the scoring scripts derive the exact same path). Upload
-uses boto3 with the same R2_* credentials / .env as the scoring scripts. The year window
-defaults to a rolling 7 years ending in the current year, so it always includes recent data.
-No GBIF account or API key is required (public occurrence-search facets).
+Each region's curves are published to its <REGION>_SEASON_CURVES R2 URL (same .env entry the
+scoring scripts read back), uploaded via boto3 with the same R2_* credentials / .env as the
+scoring scripts. The year window defaults to a rolling 7 years ending in the current year, so
+it always includes recent data. No GBIF account or API key is required (public
+occurrence-search facets).
 
 Usage:
     python build_season_curves.py                      # all regions -> R2 (next to weather data)
@@ -69,14 +68,13 @@ TAXON_MAP = {
     "truffle_b":   [8282501],  # Tuber (genus)
 }
 
-# region -> bounding box (matching each *_Scoring.py grid extent) + the weather-data env var.
-# The curves destination is derived from the weather-data path (sibling file in R2), so no
-# dedicated env var is needed — the scoring scripts derive the exact same path.
+# region -> bounding box (matching each *_Scoring.py grid extent) + its curves-destination
+# env var. The same <REGION>_SEASON_CURVES R2 URL is read back by the scoring scripts.
 REGIONS = {
-    "NE":  {"lat": (49.0, 71.5), "lon": (-25.0, 32.0),    "data_env": "NE_WEATHER_DATA"},
-    "SE":  {"lat": (34.0, 55.5), "lon": (12.0, 42.5),     "data_env": "SE_WEATHER_DATA"},
-    "USE": {"lat": (24.0, 37.5), "lon": (-106.5, -75.0),  "data_env": "USE_WEATHER_DATA"},
-    "USW": {"lat": (33.0, 49.5), "lon": (-125.5, -81.5),  "data_env": "USW_WEATHER_DATA"},
+    "NE":  {"lat": (49.0, 71.5), "lon": (-25.0, 32.0),    "env": "NE_SEASON_CURVES"},
+    "SE":  {"lat": (34.0, 55.5), "lon": (12.0, 42.5),     "env": "SE_SEASON_CURVES"},
+    "USE": {"lat": (24.0, 37.5), "lon": (-106.5, -75.0),  "env": "USE_SEASON_CURVES"},
+    "USW": {"lat": (33.0, 49.5), "lon": (-125.5, -81.5),  "env": "USW_SEASON_CURVES"},
 }
 
 _ROOT = Path(__file__).resolve().parents[2]
@@ -209,7 +207,7 @@ def main():
         if args.local_only:
             dest = str(Path(args.out_dir) / f"{region}_season_curves.json")
         else:
-            dest = get_required_env(reg["data_env"]).replace("weather_data.parquet", "season_curves.json")
+            dest = get_required_env(reg["env"])
         print(f"[{region}] {len(curves)} curve(s):")
         save_curves(curves, dest)
         print()


### PR DESCRIPTION
Four changes to the regional scoring scripts (NE, SE, USE, USW), applied identically across all four, plus a new GBIF tool. The first two are unambiguous fixes; the third is tuning; the fourth is a new data-driven input.

## 1. Lag features keyed on calendar date, not row position (bug)
`compute_lag_features` used `groupby().shift(day)` (steps back by rows). With gaps in the daily history (3 missed ingestion days in current data), the 21-step lookback spanned ~24 calendar days — over-counting cumulative rain and mislabeling temp/humidity lags. Now each "N days ago" value is taken from the row at exactly `Date - N days` (NaN if absent); duplicate `(Location_Id, Date)` pairs collapse to last.

## 2. Prune orphan score columns not in `species_params` (hygiene)
The merge step carried forward every existing parquet column forever as all-NaN. SE had `paraparasol_score` (from a since-corrected `parasol` typo). The final score-column set is now restricted to current `species_params` keys, so the closing `reindex` drops orphans — self-heals on the next run.

## 3. Weight rain above humidity (tuning)
Swapped `(wH=1.5, wW=1.25)` → `(wH=1.25, wW=1.5)` so rain (the stronger growth/fruiting trigger) outranks humidity. Total weight sum unchanged.

## 4. Empirical seasonality from GBIF sightings (new input, default behavior)
New `backend/tools/build_season_curves.py`: per region+species, queries GBIF monthly sighting counts for the target taxon and all Fungi, and uses the **target-group ratio** (target / all-fungi per month) to cancel observer-effort bias — so under-observed regions (Italy, Turkey) still yield a correct seasonal shape. Normalized ratio → bounded [0.8, 1.2] 12-month `season_curve`. Year window is a rolling 7 years ending in the current year (always includes recent data). No GBIF account/key needed.

**Fungi only (7 species).** The method assumes sighting date ≈ forageable date — true for ephemeral fungal fruiting bodies, false for perennial plants (photographed year-round regardless of forageable window; verified that nettle's curve is flat noise). The ~14 plant species stay on their hand-set `season_months`, which do encode the forageable window. Taxon keys are kingdom-verified to avoid zoological homonyms (e.g. a non-fungal `Cantharellus`).

**No new config.** Curves are stored next to the weather data in R2; the path is derived from `<REGION>_WEATHER_DATA` (swap `weather_data.parquet` → `season_curves.json`) by both the generator (uploads via boto3, same R2_*/.env as the scoring scripts) and the scoring scripts (read the identical derived path). A min-total guard skips sparse species (e.g. European St George's has 0 US records) → they fall back to `season_months`; a missing/unreadable curves file also degrades gracefully. The generator is scheduled wherever the `*_Scoring.py` jobs run (same external infra; not in this repo's workflows) — the only manual step.

## Validation (real data, all regions)
- Lag fix: every 21-day precip lag matches the true dated row; missing days → NaN; no row/column change; zero NaN/range regressions (SE's 2537 NaN are the pre-existing orphan, identical old vs new).
- Prune: SE 22→21 score cols (drops orphan); others unchanged; no real column lost.
- Weighting: all scores valid; per-cell |Δ| ~0.5; dry cells move down as intended.
- Seasonality: generator runs end-to-end against GBIF; sensible curves (NE boletus peaks Aug–Sep, chanterelle Jul–Aug, SE bimodal); scoring routes per species (mushroom uses curve, garlic falls back unchanged); derived path resolves correctly; scores stay in [0,10].
- Independent backtest (GBIF vs deployed scores): St George's ROC-AUC 0.80, morel 0.65 — the scores carry real predictive signal; the harness will validate boletus in autumn.

## Files
- `backend/EU/North_Europe/NE_Scoring.py`
- `backend/EU/South_Europe/SE_Scoring.py`
- `backend/US/USE/USE_Scoring.py`
- `backend/US/USW/USW_Scoring.py`
- `backend/tools/build_season_curves.py` (new)