### PR TITLE
perf(map): cap mobile render resolution + slider-aware routes

### DIFF
--- a/src/components/AdvancedMap.tsx
+++ b/src/components/AdvancedMap.tsx
@@ -189,6 +189,12 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
         collectResourceTiming: false,
         touchZoomRotate: true,
         trackResize: !isMobile, // Disable automatic resize only on mobile
+        // Cap render resolution on mobile: the translucent fill layers are fill-rate
+        // bound, and phones run at DPR 2-3. 1.5 cuts pixels ~2-4x with no visible loss
+        // on flat-color polygons. Desktop keeps full sharpness.
+        ...(isMobile
+          ? { pixelRatio: Math.min(window.devicePixelRatio || 1, 1.5) }
+          : {}),
         attributionControl: false,
         localIdeographFontFamily: 'sans-serif',
       });

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -292,8 +292,6 @@ export const useMapStore = create<MapState>()(
           return;
         }
 
-        const visibleLayerIds: string[] = [];
-
         layers.forEach(layer => {
           const id = layer.id;
 
@@ -314,13 +312,8 @@ export const useMapStore = create<MapState>()(
                   : 'none'
                 : 'visible';
               mapRef.setLayoutProperty(id, 'visibility', visibility);
-              console.debug(
-                `SHOWING layer: ${id} | isNumbers: ${isNumbersLayer} | visibility: ${visibility}`
-              );
-              if (visibility === 'visible') visibleLayerIds.push(id);
             } else {
               mapRef.setLayoutProperty(id, 'visibility', 'none');
-              console.debug(`HIDING unrelated species layer: ${id}`);
             }
           }
 
@@ -343,10 +336,6 @@ export const useMapStore = create<MapState>()(
             }
           }
         });
-
-        console.debug('Species selected:', selectedSpecies);
-        console.debug('Numbers visible:', numbersLayersVisible);
-        console.debug('Final visible layers:', visibleLayerIds);
       },
       // ponytail: dark mode is a full style swap now; the correct style is chosen at
       // init and on toggle, so there are no per-layer ` dark` states to restore. No-op


### PR DESCRIPTION
## Mobile performance
The map felt laggy on phones once tiles loaded. Cause is render/interaction cost, not network: ~176 translucent fill layers rasterized at phone DPR (2-3x).

- `pixelRatio` capped to 1.5 on mobile in the Map ctor -> ~2-4x fewer pixels to fill, no visible loss on flat-color polygons. Desktop keeps full sharpness.
- `updateVisibleLayers`: removed the per-layer `console.debug` that ran 349x per species/day change (+ dead accumulator).

Also on this branch: slider-aware route planner (routes interpolate scores to the active forecast day).

Full unit suite + `tsc -b`/`vite build` green. Test on the Netlify preview.