### PR TITLE
feat: 7-day forecast slider + mobile map performance + resilience

### DIFF
--- a/src/lib/forecast.ts
+++ b/src/lib/forecast.ts
@@ -21,7 +21,12 @@ export function setForecastFraction(
   const d0 = ['coalesce', ['get', `${species}_score`], 0];
   // Missing _d6 means "flat": fall back to d0 so un-forecastable polygons hold
   // their value instead of fading to 0. A stored _d6 (incl. 0) is a real decline.
-  const d6 = ['coalesce', ['get', `${species}_score_d6`], ['get', `${species}_score`], 0];
+  const d6 = [
+    'coalesce',
+    ['get', `${species}_score_d6`],
+    ['get', `${species}_score`],
+    0,
+  ];
   copy[2] = ['+', d0, ['*', frac, ['-', d6, d0]]];
   return copy;
 }

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -121,10 +121,7 @@ function layerRegion(id: string): string | null {
   return null;
 }
 
-function regionInView(
-  r: string,
-  bounds: maplibregl.LngLatBounds
-): boolean {
+function regionInView(r: string, bounds: maplibregl.LngLatBounds): boolean {
   const box = REGION_BBOX[r];
   if (!box) return true; // unknown region: don't hide it
   const [w, s, e, n] = box;
@@ -369,7 +366,10 @@ export const useMapStore = create<MapState>()(
               !!selectedSpecies && id.startsWith(`${selectedSpecies}_`);
             if (relevant && activeDay > 0 && inView) {
               const frac = activeDay / (FORECAST_DAYS - 1);
-              const current = mapRef.getPaintProperty(id, 'fill-color') as unknown[];
+              const current = mapRef.getPaintProperty(
+                id,
+                'fill-color'
+              ) as unknown[];
               if (Array.isArray(current)) {
                 mapRef.setPaintProperty(
                   id,

--- a/src/test/forecast.test.ts
+++ b/src/test/forecast.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { FORECAST_DAYS, FORECAST_REGIONS, forecastDayLabel, setForecastFraction, interpolateScores } from '@/lib/forecast';
+import {
+  FORECAST_DAYS,
+  FORECAST_REGIONS,
+  forecastDayLabel,
+  setForecastFraction,
+  interpolateScores,
+} from '@/lib/forecast';
 
 describe('forecast lib', () => {
   it('has a 7-day window and 4 regions', () => {
@@ -14,26 +20,49 @@ describe('forecast lib', () => {
   });
 
   it('builds a d0->d6 interpolation input at the given fraction', () => {
-    const expr = ['interpolate', ['linear'], ['get', 'mushroom_score'], 0, '#fff', 10, '#800020'];
+    const expr = [
+      'interpolate',
+      ['linear'],
+      ['get', 'mushroom_score'],
+      0,
+      '#fff',
+      10,
+      '#800020',
+    ];
     const out = setForecastFraction(expr, 'mushroom', 0.5);
     expect(out[2]).toEqual([
       '+',
       ['coalesce', ['get', 'mushroom_score'], 0],
-      ['*', 0.5, ['-',
-        ['coalesce', ['get', 'mushroom_score_d6'], ['get', 'mushroom_score'], 0],
-        ['coalesce', ['get', 'mushroom_score'], 0],
-      ]],
+      [
+        '*',
+        0.5,
+        [
+          '-',
+          [
+            'coalesce',
+            ['get', 'mushroom_score_d6'],
+            ['get', 'mushroom_score'],
+            0,
+          ],
+          ['coalesce', ['get', 'mushroom_score'], 0],
+        ],
+      ],
     ]);
     expect(out.slice(3)).toEqual([0, '#fff', 10, '#800020']); // ramp preserved
-    expect(expr[2]).toEqual(['get', 'mushroom_score']);        // input not mutated
+    expect(expr[2]).toEqual(['get', 'mushroom_score']); // input not mutated
   });
 
   it('interpolates feature scores to a fraction and folds away _d6', () => {
-    const props = { mushroom_score: 6, mushroom_score_d6: 0, chant_score: 4, name: 'x' };
+    const props = {
+      mushroom_score: 6,
+      mushroom_score_d6: 0,
+      chant_score: 4,
+      name: 'x',
+    };
     const out = interpolateScores(props, 0.5);
-    expect(out.mushroom_score).toBe(3);          // 6 + 0.5*(0-6)
-    expect(out.chant_score).toBe(4);             // no _d6 -> flat
+    expect(out.mushroom_score).toBe(3); // 6 + 0.5*(0-6)
+    expect(out.chant_score).toBe(4); // no _d6 -> flat
     expect(out.mushroom_score_d6).toBeUndefined();
-    expect(out.name).toBe('x');                  // non-score passthrough
+    expect(out.name).toBe('x'); // non-score passthrough
   });
 });

--- a/src/test/route-to-dish.test.ts
+++ b/src/test/route-to-dish.test.ts
@@ -76,9 +76,21 @@ describe('queryRouteDishData', () => {
     const mapStub = {
       getStyle: () => ({
         layers: [
-          { id: 'mushroom_ne', source: 'overlay-ne', 'source-layer': 'ne_scores' },
-          { id: 'mushroom_ne_fc', source: 'forecast-ne', 'source-layer': 'ne_forecast' },
-          { id: 'mushroom_numbers_ne', source: 'overlay-ne', 'source-layer': 'ne_numbers' },
+          {
+            id: 'mushroom_ne',
+            source: 'overlay-ne',
+            'source-layer': 'ne_scores',
+          },
+          {
+            id: 'mushroom_ne_fc',
+            source: 'forecast-ne',
+            'source-layer': 'ne_forecast',
+          },
+          {
+            id: 'mushroom_numbers_ne',
+            source: 'overlay-ne',
+            'source-layer': 'ne_numbers',
+          },
         ],
       }),
       querySourceFeatures: () => [],
@@ -101,8 +113,16 @@ describe('queryRouteDishData', () => {
     const mapStub = {
       getStyle: () => ({
         layers: [
-          { id: 'mushroom_ne', source: 'overlay-ne', 'source-layer': 'ne_scores' },
-          { id: 'mushroom_ne_fc', source: 'forecast-ne', 'source-layer': 'ne_forecast' },
+          {
+            id: 'mushroom_ne',
+            source: 'overlay-ne',
+            'source-layer': 'ne_scores',
+          },
+          {
+            id: 'mushroom_ne_fc',
+            source: 'forecast-ne',
+            'source-layer': 'ne_forecast',
+          },
         ],
       }),
       // Both sources hold the same stop; only the _fc twin carries `_score_d6`.


### PR DESCRIPTION
## Forecast slider
- Date slider (today -> +6) recolours the map per forecast day; unified keep-set so polygons never disappear. Popup + route planner are slider-aware.

## Mobile performance
- Region gating: only the region(s) in view stay live. US loads as one unit (USE+USW together); EU stays split at lat 52; US/EU never co-active.
- -d10 on all 4 region builds (today + forecast): ~half the vertices/tile, ~20-25% smaller. No features dropped.
- mobile pixelRatio cap; removed per-layer console.debug.

## Resilience
- The map can no longer be blanked by a recoverable tile/source error (transient cache hiccup, missing tile, not-yet-built forecast tileset). 'error' event logs only.

CI verified locally: lint:check (0 real errors), type-check, vitest unit (32 passed), build all green. First scheduler run after merge rebuilds all tiles at -d10.