### PR TITLE
perf(tiles): switch tile detail -d10 -> -d9 (all 4 regions)

### DIFF
--- a/backend/EU/North_Europe/NE_MapLayer.py
+++ b/backend/EU/North_Europe/NE_MapLayer.py
@@ -645,7 +645,7 @@ def build_mbtiles_from_geojson(geojson_path: Path, mbtiles_path: Path, layer_nam
         "--force",
         "--no-tile-size-limit" if keep_all else "--drop-densest-as-needed",
         "--simplification=4",
-        "-d10",  # ~600m coord grid at z6: ~half the vertices/tile -> smaller per-tile payloads, faster loads
+        "-d9",  # ~1.2km coord grid at z6: ~half the vertices of -d10 again; drops the smallest slivers. today+forecast use the same detail so the slider stays consistent
         "-l", layer_name,
         str(geojson_path),
     ]

--- a/backend/EU/South_Europe/SE_MapLayer.py
+++ b/backend/EU/South_Europe/SE_MapLayer.py
@@ -643,7 +643,7 @@ def build_mbtiles_from_geojson(geojson_path: Path, mbtiles_path: Path, layer_nam
         "--force",
         "--no-tile-size-limit" if keep_all else "--drop-densest-as-needed",
         "--simplification=4",
-        "-d10",  # ~600m coord grid at z6: ~half the vertices/tile -> smaller per-tile payloads, faster loads
+        "-d9",  # ~1.2km coord grid at z6: ~half the vertices of -d10 again; drops the smallest slivers. today+forecast use the same detail so the slider stays consistent
         "-l", layer_name,
         str(geojson_path),
     ]

--- a/backend/US/USE/USE_MapLayer.py
+++ b/backend/US/USE/USE_MapLayer.py
@@ -637,7 +637,7 @@ def build_mbtiles_from_geojson(geojson_path: Path, mbtiles_path: Path, layer_nam
         "--force",
         "--no-tile-size-limit" if keep_all else "--drop-densest-as-needed",
         "--simplification=4",
-        "-d10",  # ~600m coord grid at z6: ~half the vertices/tile -> smaller per-tile payloads, faster loads
+        "-d9",  # ~1.2km coord grid at z6: ~half the vertices of -d10 again; drops the smallest slivers. today+forecast use the same detail so the slider stays consistent
         "-l", layer_name,
         str(geojson_path),
     ]

--- a/backend/US/USW/USW_MapLayer.py
+++ b/backend/US/USW/USW_MapLayer.py
@@ -637,7 +637,7 @@ def build_mbtiles_from_geojson(geojson_path: Path, mbtiles_path: Path, layer_nam
         "--force",
         "--no-tile-size-limit" if keep_all else "--drop-densest-as-needed",
         "--simplification=4",
-        "-d10",  # ~600m coord grid at z6: ~half the vertices/tile -> smaller per-tile payloads, faster loads
+        "-d9",  # ~1.2km coord grid at z6: ~half the vertices of -d10 again; drops the smallest slivers. today+forecast use the same detail so the slider stays consistent
         "-l", layer_name,
         str(geojson_path),
     ]


### PR DESCRIPTION
Switches the tippecanoe tile detail from -d10 to -d9 across NE/SE/USE/USW, today + forecast.

- ~half the vertices of -d10 again (~4x lighter than production), smaller per-tile payloads.
- Applied identically to today + forecast so the forecast slider stays consistent (no pop-in when sliding).

Tradeoff: the smallest sliver polygons collapse at the ~1.2km grid (~17% fewer features/tile vs -d10) and edges are blockier. Takes effect on the next scheduler rebuild.