### PR TITLE
Add elevation data sources (EU-DEM + HydroSHEDS) to instructions page

### DIFF
--- a/src/i18n/locales/de/instructions.json
+++ b/src/i18n/locales/de/instructions.json
@@ -80,6 +80,12 @@
         "source": "Quelle: U.S. Geological Survey (USGS), Multi-Resolution Land Characteristics (MRLC) Consortium",
         "citation": "Zitat: U.S. Geological Survey. Annual NLCD (National Land Cover Database) - The next generation of land cover mapping. Fact Sheet 2025-3001."
       },
+      "eudem": {
+        "title": "4. EU-DEM (Digitales Höhenmodell)",
+        "description": "Bereitgestellt vom Copernicus Land Monitoring Service (Europäische Umweltagentur), ist EU-DEM v1.1 ein europaweites digitales Höhenmodell mit einer Auflösung von 25 Metern. Die Höhenlage beeinflusst Temperatur, Feuchtigkeit und die Verteilung von Pilz- und Pflanzenlebensräumen in der Landschaft.",
+        "source": "Quelle: Copernicus Land Monitoring Service, Europäische Umweltagentur (EEA)",
+        "citation": "Zitat: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
+      },
       "additional": "Weitere Quellen wie Wetter-APIs, Fernerkundungsdaten und Hang-/Expositionsmodelle werden integriert, um die Prognosegenauigkeit kontinuierlich zu verbessern."
     }
   }

--- a/src/i18n/locales/de/instructions.json
+++ b/src/i18n/locales/de/instructions.json
@@ -86,6 +86,12 @@
         "source": "Quelle: Copernicus Land Monitoring Service, Europäische Umweltagentur (EEA)",
         "citation": "Zitat: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
       },
+      "hydrosheds": {
+        "title": "5. HydroSHEDS (Höhenmodell USA)",
+        "description": "Entwickelt vom World Wildlife Fund (WWF) auf Basis der NASA-SRTM-Mission, bietet HydroSHEDS ein hydrologisch aufbereitetes digitales Höhenmodell Nordamerikas mit einer Auflösung von ca. 90 Metern (3 Bogensekunden). Es liefert Gelände- und Höhendaten für Sammelgebiete in den USA und ergänzt EU-DEM in Europa.",
+        "source": "Quelle: World Wildlife Fund (WWF), HydroSHEDS (abgeleitet von NASA SRTM)",
+        "citation": "Zitat: Lehner, B., Verdin, K., & Jarvis, A. (2008). New global hydrography derived from spaceborne elevation data. Eos, Transactions AGU, 89(10), 93-94."
+      },
       "additional": "Weitere Quellen wie Wetter-APIs, Fernerkundungsdaten und Hang-/Expositionsmodelle werden integriert, um die Prognosegenauigkeit kontinuierlich zu verbessern."
     }
   }

--- a/src/i18n/locales/en/instructions.json
+++ b/src/i18n/locales/en/instructions.json
@@ -86,6 +86,12 @@
         "source": "Source: Copernicus Land Monitoring Service, European Environment Agency (EEA)",
         "citation": "Citation: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
       },
+      "hydrosheds": {
+        "title": "5. HydroSHEDS (U.S. Elevation Model)",
+        "description": "Developed by the World Wildlife Fund (WWF) from NASA's SRTM mission, HydroSHEDS provides a hydrologically conditioned digital elevation model of North America at ~90-meter (3 arc-second) resolution. It supplies terrain and elevation for U.S. foraging areas, complementing EU-DEM in Europe.",
+        "source": "Source: World Wildlife Fund (WWF), HydroSHEDS (derived from NASA SRTM)",
+        "citation": "Citation: Lehner, B., Verdin, K., & Jarvis, A. (2008). New global hydrography derived from spaceborne elevation data. Eos, Transactions AGU, 89(10), 93-94."
+      },
       "additional": "Additional sources such as meteorological APIs, remote sensing layers, and slope/aspect models are integrated to continuously improve prediction accuracy."
     }
   }

--- a/src/i18n/locales/en/instructions.json
+++ b/src/i18n/locales/en/instructions.json
@@ -80,6 +80,12 @@
         "source": "Source: U.S. Geological Survey (USGS), Multi-Resolution Land Characteristics (MRLC) Consortium",
         "citation": "Citation: U.S. Geological Survey. Annual NLCD (National Land Cover Database) - The next generation of land cover mapping. Fact Sheet 2025-3001."
       },
+      "eudem": {
+        "title": "4. EU-DEM (Digital Elevation Model)",
+        "description": "Provided by the Copernicus Land Monitoring Service (European Environment Agency), EU-DEM v1.1 is a pan-European digital elevation model at 25-meter resolution. Elevation shapes temperature, moisture and the distribution of fungal and plant habitats across the landscape.",
+        "source": "Source: Copernicus Land Monitoring Service, European Environment Agency (EEA)",
+        "citation": "Citation: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
+      },
       "additional": "Additional sources such as meteorological APIs, remote sensing layers, and slope/aspect models are integrated to continuously improve prediction accuracy."
     }
   }

--- a/src/i18n/locales/es/instructions.json
+++ b/src/i18n/locales/es/instructions.json
@@ -86,6 +86,12 @@
         "source": "Fuente: Copernicus Land Monitoring Service, Agencia Europea de Medio Ambiente (EEA)",
         "citation": "Cita: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
       },
+      "hydrosheds": {
+        "title": "5. HydroSHEDS (Modelo de Elevación de EE. UU.)",
+        "description": "Desarrollado por el World Wildlife Fund (WWF) a partir de la misión SRTM de la NASA, HydroSHEDS ofrece un modelo digital de elevación hidrológicamente acondicionado de América del Norte con una resolución de ~90 metros (3 segundos de arco). Proporciona datos de terreno y altitud para las zonas de recolección en EE. UU., complementando EU-DEM en Europa.",
+        "source": "Fuente: World Wildlife Fund (WWF), HydroSHEDS (derivado de NASA SRTM)",
+        "citation": "Cita: Lehner, B., Verdin, K., & Jarvis, A. (2008). New global hydrography derived from spaceborne elevation data. Eos, Transactions AGU, 89(10), 93-94."
+      },
       "additional": "Se integran fuentes adicionales como APIs meteorológicas, capas de teledetección y modelos de pendiente/orientación para mejorar continuamente la precisión de las predicciones."
     }
   }

--- a/src/i18n/locales/es/instructions.json
+++ b/src/i18n/locales/es/instructions.json
@@ -80,6 +80,12 @@
         "source": "Fuente: U.S. Geological Survey (USGS), Multi-Resolution Land Characteristics (MRLC) Consortium",
         "citation": "Cita: U.S. Geological Survey. Annual NLCD (National Land Cover Database) - The next generation of land cover mapping. Fact Sheet 2025-3001."
       },
+      "eudem": {
+        "title": "4. EU-DEM (Modelo Digital de Elevación)",
+        "description": "Proporcionado por el Copernicus Land Monitoring Service (Agencia Europea de Medio Ambiente), EU-DEM v1.1 es un modelo digital de elevación paneuropeo con una resolución de 25 metros. La altitud influye en la temperatura, la humedad y la distribución de los hábitats de hongos y plantas en el paisaje.",
+        "source": "Fuente: Copernicus Land Monitoring Service, Agencia Europea de Medio Ambiente (EEA)",
+        "citation": "Cita: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
+      },
       "additional": "Se integran fuentes adicionales como APIs meteorológicas, capas de teledetección y modelos de pendiente/orientación para mejorar continuamente la precisión de las predicciones."
     }
   }

--- a/src/i18n/locales/fr/instructions.json
+++ b/src/i18n/locales/fr/instructions.json
@@ -80,6 +80,12 @@
         "source": "Source : U.S. Geological Survey (USGS), Multi-Resolution Land Characteristics (MRLC) Consortium",
         "citation": "Citation : U.S. Geological Survey. Annual NLCD (National Land Cover Database) - The next generation of land cover mapping. Fact Sheet 2025-3001."
       },
+      "eudem": {
+        "title": "4. EU-DEM (Modèle Numérique de Terrain)",
+        "description": "Fourni par le Copernicus Land Monitoring Service (Agence européenne pour l'environnement), EU-DEM v1.1 est un modèle numérique de terrain paneuropéen à une résolution de 25 mètres. L'altitude influence la température, l'humidité et la répartition des habitats de champignons et de plantes dans le paysage.",
+        "source": "Source : Copernicus Land Monitoring Service, Agence européenne pour l'environnement (AEE)",
+        "citation": "Citation : European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
+      },
       "additional": "D'autres sources comme les API météorologiques, les couches de télédétection et les modèles de pente/orientation sont intégrées pour améliorer continuellement la précision des prédictions."
     }
   }

--- a/src/i18n/locales/fr/instructions.json
+++ b/src/i18n/locales/fr/instructions.json
@@ -86,6 +86,12 @@
         "source": "Source : Copernicus Land Monitoring Service, Agence européenne pour l'environnement (AEE)",
         "citation": "Citation : European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
       },
+      "hydrosheds": {
+        "title": "5. HydroSHEDS (Modèle d'élévation des États-Unis)",
+        "description": "Développé par le World Wildlife Fund (WWF) à partir de la mission SRTM de la NASA, HydroSHEDS fournit un modèle numérique de terrain hydrologiquement corrigé de l'Amérique du Nord à une résolution d'environ 90 mètres (3 secondes d'arc). Il fournit le relief et l'altitude pour les zones de cueillette aux États-Unis, en complément d'EU-DEM en Europe.",
+        "source": "Source : World Wildlife Fund (WWF), HydroSHEDS (dérivé de NASA SRTM)",
+        "citation": "Citation : Lehner, B., Verdin, K., & Jarvis, A. (2008). New global hydrography derived from spaceborne elevation data. Eos, Transactions AGU, 89(10), 93-94."
+      },
       "additional": "D'autres sources comme les API météorologiques, les couches de télédétection et les modèles de pente/orientation sont intégrées pour améliorer continuellement la précision des prédictions."
     }
   }

--- a/src/i18n/locales/it/instructions.json
+++ b/src/i18n/locales/it/instructions.json
@@ -86,6 +86,12 @@
         "source": "Fonte: Copernicus Land Monitoring Service, Agenzia Europea per l'Ambiente (EEA)",
         "citation": "Citazione: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
       },
+      "hydrosheds": {
+        "title": "5. HydroSHEDS (Modello di Elevazione degli Stati Uniti)",
+        "description": "Sviluppato dal World Wildlife Fund (WWF) a partire dalla missione SRTM della NASA, HydroSHEDS fornisce un modello digitale di elevazione idrologicamente condizionato del Nord America con una risoluzione di circa 90 metri (3 secondi d'arco). Fornisce dati di terreno e altitudine per le aree di raccolta negli Stati Uniti, integrando EU-DEM in Europa.",
+        "source": "Fonte: World Wildlife Fund (WWF), HydroSHEDS (derivato da NASA SRTM)",
+        "citation": "Citazione: Lehner, B., Verdin, K., & Jarvis, A. (2008). New global hydrography derived from spaceborne elevation data. Eos, Transactions AGU, 89(10), 93-94."
+      },
       "additional": "Fonti aggiuntive come API meteorologiche, livelli di telerilevamento e modelli di pendenza/aspetto sono integrati per migliorare continuamente l'accuratezza della previsione."
     }
   }

--- a/src/i18n/locales/it/instructions.json
+++ b/src/i18n/locales/it/instructions.json
@@ -80,6 +80,12 @@
         "source": "Fonte: U.S. Geological Survey (USGS), Multi-Resolution Land Characteristics (MRLC) Consortium",
         "citation": "Citazione: U.S. Geological Survey. Annual NLCD (National Land Cover Database) - The next generation of land cover mapping. Fact Sheet 2025-3001."
       },
+      "eudem": {
+        "title": "4. EU-DEM (Modello Digitale di Elevazione)",
+        "description": "Fornito dal Copernicus Land Monitoring Service (Agenzia Europea per l'Ambiente), EU-DEM v1.1 è un modello digitale di elevazione paneuropeo con una risoluzione di 25 metri. L'altitudine influenza la temperatura, l'umidità e la distribuzione degli habitat di funghi e piante nel paesaggio.",
+        "source": "Fonte: Copernicus Land Monitoring Service, Agenzia Europea per l'Ambiente (EEA)",
+        "citation": "Citazione: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
+      },
       "additional": "Fonti aggiuntive come API meteorologiche, livelli di telerilevamento e modelli di pendenza/aspetto sono integrati per migliorare continuamente l'accuratezza della previsione."
     }
   }

--- a/src/i18n/locales/pt/instructions.json
+++ b/src/i18n/locales/pt/instructions.json
@@ -86,6 +86,12 @@
         "source": "Fonte: Copernicus Land Monitoring Service, Agência Europeia do Ambiente (EEA)",
         "citation": "Citação: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
       },
+      "hydrosheds": {
+        "title": "5. HydroSHEDS (Modelo de Elevação dos EUA)",
+        "description": "Desenvolvido pelo World Wildlife Fund (WWF) a partir da missão SRTM da NASA, o HydroSHEDS fornece um modelo digital de elevação hidrologicamente condicionado da América do Norte com resolução de ~90 metros (3 segundos de arco). Fornece dados de terreno e altitude para as áreas de coleta nos EUA, complementando o EU-DEM na Europa.",
+        "source": "Fonte: World Wildlife Fund (WWF), HydroSHEDS (derivado de NASA SRTM)",
+        "citation": "Citação: Lehner, B., Verdin, K., & Jarvis, A. (2008). New global hydrography derived from spaceborne elevation data. Eos, Transactions AGU, 89(10), 93-94."
+      },
       "additional": "Fontes adicionais como APIs meteorológicas, camadas de sensoriamento remoto e modelos de inclinação/orientação são integradas para melhorar continuamente a precisão das previsões."
     }
   }

--- a/src/i18n/locales/pt/instructions.json
+++ b/src/i18n/locales/pt/instructions.json
@@ -80,6 +80,12 @@
         "source": "Fonte: U.S. Geological Survey (USGS), Multi-Resolution Land Characteristics (MRLC) Consortium",
         "citation": "Citação: U.S. Geological Survey. Annual NLCD (National Land Cover Database) - The next generation of land cover mapping. Fact Sheet 2025-3001."
       },
+      "eudem": {
+        "title": "4. EU-DEM (Modelo Digital de Elevação)",
+        "description": "Fornecido pelo Copernicus Land Monitoring Service (Agência Europeia do Ambiente), o EU-DEM v1.1 é um modelo digital de elevação pan-europeu com resolução de 25 metros. A altitude influencia a temperatura, a humidade e a distribuição dos habitats de cogumelos e plantas na paisagem.",
+        "source": "Fonte: Copernicus Land Monitoring Service, Agência Europeia do Ambiente (EEA)",
+        "citation": "Citação: European Environment Agency (2016). European Digital Elevation Model (EU-DEM), version 1.1. Copernicus Land Monitoring Service."
+      },
       "additional": "Fontes adicionais como APIs meteorológicas, camadas de sensoriamento remoto e modelos de inclinação/orientação são integradas para melhorar continuamente a precisão das previsões."
     }
   }

--- a/src/pages/InstructionsPage.tsx
+++ b/src/pages/InstructionsPage.tsx
@@ -317,6 +317,21 @@ export default function InstructionsPage() {
                     </p>
                   </div>
 
+                  <div className='p-4 rounded-lg bg-purple-50 dark:bg-purple-900/20'>
+                    <h5 className='font-semibold text-gray-900 dark:text-white mb-2'>
+                      {t('prediction.keyDatasets.eudem.title')}
+                    </h5>
+                    <p className='text-gray-700 dark:text-gray-300 text-sm mb-2'>
+                      {t('prediction.keyDatasets.eudem.description')}
+                    </p>
+                    <p className='text-gray-600 dark:text-gray-400 text-xs'>
+                      {t('prediction.keyDatasets.eudem.source')}
+                    </p>
+                    <p className='text-gray-600 dark:text-gray-400 text-xs'>
+                      {t('prediction.keyDatasets.eudem.citation')}
+                    </p>
+                  </div>
+
                   <p className='text-gray-700 dark:text-gray-300 text-sm'>
                     {t('prediction.keyDatasets.additional')}
                   </p>

--- a/src/pages/InstructionsPage.tsx
+++ b/src/pages/InstructionsPage.tsx
@@ -332,6 +332,21 @@ export default function InstructionsPage() {
                     </p>
                   </div>
 
+                  <div className='p-4 rounded-lg bg-teal-50 dark:bg-teal-900/20'>
+                    <h5 className='font-semibold text-gray-900 dark:text-white mb-2'>
+                      {t('prediction.keyDatasets.hydrosheds.title')}
+                    </h5>
+                    <p className='text-gray-700 dark:text-gray-300 text-sm mb-2'>
+                      {t('prediction.keyDatasets.hydrosheds.description')}
+                    </p>
+                    <p className='text-gray-600 dark:text-gray-400 text-xs'>
+                      {t('prediction.keyDatasets.hydrosheds.source')}
+                    </p>
+                    <p className='text-gray-600 dark:text-gray-400 text-xs'>
+                      {t('prediction.keyDatasets.hydrosheds.citation')}
+                    </p>
+                  </div>
+
                   <p className='text-gray-700 dark:text-gray-300 text-sm'>
                     {t('prediction.keyDatasets.additional')}
                   </p>


### PR DESCRIPTION
## What

Adds the two elevation datasets that actually power the altitude feature to the **Key Datasets** section of the instructions page, in all six languages:

- **EU-DEM v1.1** (Copernicus / EEA, 25 m) — Europe. Sampled in `Corinne Data/Distance_Water/Altitude.ipynb`.
- **HydroSHEDS** (WWF, SRTM-derived, ~90 m) — US. Sampled from `na_con_3s.tif` in `US/Static Info/prep_coords.ipynb`.

Mirrors the existing per-region source pattern (ESDAC + CORINE for Europe, NLCD for US) and the existing card layout — each card has title, description, source, and citation.

## Files

- `src/pages/InstructionsPage.tsx` — two new dataset cards (cards 4 and 5)
- `src/i18n/locales/{de,en,es,fr,it,pt}/instructions.json` — `prediction.keyDatasets.eudem.*` and `.hydrosheds.*` keys

## Verification

- All six locale JSON files validated as parseable.
- New cards reuse the exact structure/keys of the existing CORINE/pH/NLCD cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
