### PR TITLE
Add Positron & Dark Matter map styles (4-way style toggle) + map/route fixes

### DIFF
--- a/public/funges_style_darkmatter.json
+++ b/public/funges_style_darkmatter.json
@@ -10536,7 +10536,7 @@
       "paint": {
         "text-color": "#5a7280",
         "text-halo-color": "#000000",
-        "text-halo-width": 1.2
+        "text-halo-width": 1.6
       }
     },
     {
@@ -10606,7 +10606,7 @@
       "paint": {
         "text-color": "#a8a8a8",
         "text-halo-color": "#000000",
-        "text-halo-width": 1.2
+        "text-halo-width": 1.6
       }
     },
     {
@@ -10670,7 +10670,7 @@
       "paint": {
         "text-color": "#a8a8a8",
         "text-halo-color": "#000000",
-        "text-halo-width": 1.2
+        "text-halo-width": 1.6
       }
     },
     {
@@ -10739,7 +10739,7 @@
       "paint": {
         "text-color": "#a8a8a8",
         "text-halo-color": "#000000",
-        "text-halo-width": 1.2
+        "text-halo-width": 1.6
       }
     },
     {
@@ -10803,7 +10803,7 @@
       "paint": {
         "text-color": "#a8a8a8",
         "text-halo-color": "#000000",
-        "text-halo-width": 1.2
+        "text-halo-width": 1.6
       }
     }
   ]

--- a/public/funges_style_darkmatter.json
+++ b/public/funges_style_darkmatter.json
@@ -1,0 +1,10851 @@
+{
+  "version": 8,
+  "name": "Funges Dark Matter",
+  "metadata": {
+    "maputnik:renderer": "mlgljs",
+    "custom:based_on": "funges_style.json (CARTO recolor)"
+  },
+  "center": [
+    10.679681327683397,
+    59.20531786301794
+  ],
+  "zoom": 5.10124672030565,
+  "bearing": 0,
+  "pitch": 0,
+  "light": {
+    "anchor": "map",
+    "intensity": 0.3,
+    "position": [
+      1.5,
+      235,
+      30
+    ]
+  },
+  "projection": {
+    "type": "mercator"
+  },
+  "sources": {
+    "aws": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/basemap/world_z12_20260619.pmtiles"
+    },
+    "overlay-ne": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/ne_forecast.pmtiles"
+    },
+    "overlay-se": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/se_forecast.pmtiles"
+    },
+    "overlay-use": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/use_forecast.pmtiles"
+    },
+    "overlay-usw": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/usw_forecast.pmtiles"
+    }
+  },
+  "sprite": "https://protomaps.github.io/basemaps-assets/sprites/v4/dark",
+  "glyphs": "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
+  "created": "0001-01-01T00:00:00Z",
+  "modified": "0001-01-01T00:00:00Z",
+  "id": "hybrid_plus-global-light-default-3.1.0",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#0c0f11"
+      }
+    },
+    {
+      "id": "earth",
+      "type": "fill",
+      "source": "aws",
+      "source-layer": "earth",
+      "filter": [
+        "==",
+        [
+          "geometry-type"
+        ],
+        "Polygon"
+      ],
+      "paint": {
+        "fill-color": "#111314"
+      }
+    },
+    {
+      "id": "landuse_green",
+      "type": "fill",
+      "source": "aws",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Polygon"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "forest",
+            "wood",
+            "nature_reserve",
+            "national_park",
+            "protected_area",
+            "park",
+            "grass",
+            "meadow",
+            "scrub",
+            "grassland"
+          ],
+          true,
+          false
+        ]
+      ],
+      "paint": {
+        "fill-color": "#161c14",
+        "fill-opacity": 0.6
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "aws",
+      "source-layer": "water",
+      "filter": [
+        "==",
+        [
+          "geometry-type"
+        ],
+        "Polygon"
+      ],
+      "paint": {
+        "fill-color": "#0c0f11"
+      }
+    },
+    {
+      "id": "waterway",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "water",
+      "minzoom": 9,
+      "filter": [
+        "==",
+        [
+          "geometry-type"
+        ],
+        "LineString"
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#1b2327",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          9,
+          0.4,
+          12,
+          1.2
+        ]
+      }
+    },
+    {
+      "id": "road_minor",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "minor_road",
+            "unclassified",
+            "track"
+          ],
+          true,
+          false
+        ],
+        [
+          "!=",
+          [
+            "get",
+            "kind_detail"
+          ],
+          "service"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#1c1c1c",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          11,
+          0.3,
+          12,
+          0.9
+        ]
+      }
+    },
+    {
+      "id": "road_medium",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "secondary",
+            "tertiary"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#242424",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          0.4,
+          12,
+          1.6
+        ]
+      }
+    },
+    {
+      "id": "road_major",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "motorway",
+            "trunk",
+            "primary"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2e2e2e",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0.5,
+          9,
+          1.3,
+          12,
+          3
+        ]
+      }
+    },
+    {
+      "id": "boundary_region",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "boundaries",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "region",
+            "macroregion"
+          ],
+          true,
+          false
+        ],
+        [
+          "match",
+          [
+            "to-number",
+            [
+              "get",
+              "kind_detail"
+            ]
+          ],
+          [
+            3,
+            4
+          ],
+          true,
+          false
+        ],
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#232323",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          0.4,
+          12,
+          1
+        ],
+        "line-dasharray": [
+          2,
+          2
+        ]
+      }
+    },
+    {
+      "id": "boundary_country",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "boundaries",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "country"
+        ],
+        [
+          "==",
+          [
+            "to-number",
+            [
+              "get",
+              "kind_detail"
+            ]
+          ],
+          2
+        ],
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2d2d2d",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          1,
+          0.6,
+          6,
+          1.3
+        ]
+      }
+    },
+    {
+      "id": "water_label",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "water",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          10,
+          8,
+          13
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#5a7280",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_settlement",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "town",
+            "village",
+            "hamlet",
+            "borough",
+            "suburb"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          7,
+          10,
+          12,
+          14
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#a8a8a8",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_city",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "locality"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          11,
+          10,
+          16
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#a8a8a8",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_region",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "region",
+            "macroregion"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          10,
+          8,
+          13
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#a8a8a8",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_country",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "country"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          1,
+          11,
+          4,
+          15
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#a8a8a8",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "walnut_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.2)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.2)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast"
+    },
+    {
+      "id": "mushroom_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast"
+    },
+    {
+      "id": "mushroom_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast"
+    },
+    {
+      "id": "mushroom_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast"
+    },
+    {
+      "id": "walnut_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "walnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "walnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "walnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "walnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "walnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "walnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "walnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "walnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "truffle_b_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "truffle_b_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "truffle_b_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "truffle_b_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "truffle_b_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "truffle_b_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "truffle_b_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "truffle_b_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "strawberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "strawberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "strawberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "strawberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "strawberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "strawberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "strawberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "strawberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "st_george_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "st_george_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "st_george_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "st_george_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "st_george_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "st_george_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "st_george_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "st_george_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "sorrel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "sorrel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "sorrel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "sorrel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "sorrel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "sorrel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "sorrel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "sorrel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "raspberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "raspberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "raspberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "raspberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "raspberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "raspberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "raspberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "raspberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "parasol_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "parasol_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "parasol_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "parasol_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "parasol_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "parasol_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "parasol_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "parasol_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "nettle_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "nettle_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "nettle_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "nettle_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "nettle_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "nettle_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "nettle_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "nettle_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "morel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "morel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "morel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "morel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "morel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "morel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "morel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "morel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "masterwort_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "masterwort_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "masterwort_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "masterwort_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "masterwort_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "masterwort_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "masterwort_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "masterwort_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "lingonb_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "lingonb_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "lingonb_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "lingonb_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "lingonb_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "lingonb_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "lingonb_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "lingonb_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "garlic_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "garlic_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "garlic_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "garlic_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "garlic_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "garlic_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "garlic_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "garlic_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "dandelion_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "dandelion_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "dandelion_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "dandelion_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "dandelion_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "dandelion_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "dandelion_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "dandelion_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chickweed_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chickweed_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chickweed_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chickweed_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chickweed_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chickweed_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chickweed_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chickweed_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chestnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chestnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chestnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chestnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chestnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chestnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chestnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chestnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "black_chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "black_chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "black_chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "black_chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "black_chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "black_chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "black_chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "black_chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "asparagus_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "asparagus_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "asparagus_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "asparagus_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "asparagus_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "asparagus_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "asparagus_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "asparagus_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "artichoke_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "artichoke_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "artichoke_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "artichoke_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "artichoke_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "artichoke_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "artichoke_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "artichoke_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "amaranth_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "amaranth_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "amaranth_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "amaranth_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "amaranth_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "amaranth_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "amaranth_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "amaranth_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "mushroom_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "mushroom_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "mushroom_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "mushroom_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "mushroom_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "mushroom_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "mushroom_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "mushroom_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    }
+  ]
+}

--- a/public/funges_style_darkmatter.json
+++ b/public/funges_style_darkmatter.json
@@ -76,47 +76,6 @@
       }
     },
     {
-      "id": "landuse_green",
-      "type": "fill",
-      "source": "aws",
-      "source-layer": "landuse",
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Polygon"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind"
-          ],
-          [
-            "forest",
-            "wood",
-            "nature_reserve",
-            "national_park",
-            "protected_area",
-            "park",
-            "grass",
-            "meadow",
-            "scrub",
-            "grassland"
-          ],
-          true,
-          false
-        ]
-      ],
-      "paint": {
-        "fill-color": "#161c14",
-        "fill-opacity": 0.6
-      }
-    },
-    {
       "id": "water",
       "type": "fill",
       "source": "aws",

--- a/public/funges_style_darkmatter.json
+++ b/public/funges_style_darkmatter.json
@@ -126,168 +126,6 @@
       }
     },
     {
-      "id": "road_minor",
-      "type": "line",
-      "source": "aws",
-      "source-layer": "roads",
-      "minzoom": 11,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "LineString"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind"
-          ],
-          [
-            "minor_road",
-            "unclassified",
-            "track"
-          ],
-          true,
-          false
-        ],
-        [
-          "!=",
-          [
-            "get",
-            "kind_detail"
-          ],
-          "service"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#1c1c1c",
-        "line-width": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          11,
-          0.3,
-          12,
-          0.9
-        ]
-      }
-    },
-    {
-      "id": "road_medium",
-      "type": "line",
-      "source": "aws",
-      "source-layer": "roads",
-      "minzoom": 8,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "LineString"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind_detail"
-          ],
-          [
-            "secondary",
-            "tertiary"
-          ],
-          true,
-          false
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#242424",
-        "line-width": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          8,
-          0.4,
-          12,
-          1.6
-        ]
-      }
-    },
-    {
-      "id": "road_major",
-      "type": "line",
-      "source": "aws",
-      "source-layer": "roads",
-      "minzoom": 5,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "LineString"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind_detail"
-          ],
-          [
-            "motorway",
-            "trunk",
-            "primary"
-          ],
-          true,
-          false
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#2e2e2e",
-        "line-width": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          5,
-          0.5,
-          9,
-          1.3,
-          12,
-          3
-        ]
-      }
-    },
-    {
       "id": "boundary_region",
       "type": "line",
       "source": "aws",
@@ -411,331 +249,6 @@
           6,
           1.3
         ]
-      }
-    },
-    {
-      "id": "water_label",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "water",
-      "minzoom": 3,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "has",
-          "name"
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          3,
-          10,
-          8,
-          13
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#5a7280",
-        "text-halo-color": "#000000",
-        "text-halo-width": 1.2
-      }
-    },
-    {
-      "id": "place_settlement",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "places",
-      "minzoom": 7,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind_detail"
-          ],
-          [
-            "town",
-            "village",
-            "hamlet",
-            "borough",
-            "suburb"
-          ],
-          true,
-          false
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Medium"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          7,
-          10,
-          12,
-          14
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#a8a8a8",
-        "text-halo-color": "#000000",
-        "text-halo-width": 1.2
-      }
-    },
-    {
-      "id": "place_city",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "places",
-      "minzoom": 3,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "==",
-          [
-            "get",
-            "kind"
-          ],
-          "locality"
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Medium"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          3,
-          11,
-          10,
-          16
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible",
-        "text-transform": "uppercase",
-        "text-letter-spacing": 0.08
-      },
-      "paint": {
-        "text-color": "#a8a8a8",
-        "text-halo-color": "#000000",
-        "text-halo-width": 1.2
-      }
-    },
-    {
-      "id": "place_region",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "places",
-      "minzoom": 4,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind"
-          ],
-          [
-            "region",
-            "macroregion"
-          ],
-          true,
-          false
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          4,
-          10,
-          8,
-          13
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible",
-        "text-transform": "uppercase",
-        "text-letter-spacing": 0.08
-      },
-      "paint": {
-        "text-color": "#a8a8a8",
-        "text-halo-color": "#000000",
-        "text-halo-width": 1.2
-      }
-    },
-    {
-      "id": "place_country",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "places",
-      "minzoom": 1,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "==",
-          [
-            "get",
-            "kind"
-          ],
-          "country"
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Medium"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          1,
-          11,
-          4,
-          15
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible",
-        "text-transform": "uppercase",
-        "text-letter-spacing": 0.08
-      },
-      "paint": {
-        "text-color": "#a8a8a8",
-        "text-halo-color": "#000000",
-        "text-halo-width": 1.2
       }
     },
     {
@@ -10804,6 +10317,493 @@
         ],
         "text-size": 20,
         "visibility": "none"
+      }
+    },
+    {
+      "id": "road_minor",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "minor_road",
+            "unclassified",
+            "track"
+          ],
+          true,
+          false
+        ],
+        [
+          "!=",
+          [
+            "get",
+            "kind_detail"
+          ],
+          "service"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#1c1c1c",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          11,
+          0.3,
+          12,
+          0.9
+        ]
+      }
+    },
+    {
+      "id": "road_medium",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "secondary",
+            "tertiary"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#242424",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          0.4,
+          12,
+          1.6
+        ]
+      }
+    },
+    {
+      "id": "road_major",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "motorway",
+            "trunk",
+            "primary"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#2e2e2e",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0.5,
+          9,
+          1.3,
+          12,
+          3
+        ]
+      }
+    },
+    {
+      "id": "water_label",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "water",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          10,
+          8,
+          13
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#5a7280",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_settlement",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "town",
+            "village",
+            "hamlet",
+            "borough",
+            "suburb"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          7,
+          10,
+          12,
+          14
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#a8a8a8",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_city",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "locality"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          11,
+          10,
+          16
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#a8a8a8",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_region",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "region",
+            "macroregion"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          10,
+          8,
+          13
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#a8a8a8",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_country",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "country"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          1,
+          11,
+          4,
+          15
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#a8a8a8",
+        "text-halo-color": "#000000",
+        "text-halo-width": 1.2
       }
     }
   ]

--- a/public/funges_style_positron.json
+++ b/public/funges_style_positron.json
@@ -10575,9 +10575,9 @@
         "visibility": "visible"
       },
       "paint": {
-        "text-color": "#7d94a3",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
+        "text-color": "#6d8595",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.6
       }
     },
     {
@@ -10645,9 +10645,9 @@
         "visibility": "visible"
       },
       "paint": {
-        "text-color": "#5c5f63",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
+        "text-color": "#33373b",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.6
       }
     },
     {
@@ -10709,9 +10709,9 @@
         "text-letter-spacing": 0.08
       },
       "paint": {
-        "text-color": "#5c5f63",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
+        "text-color": "#33373b",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.6
       }
     },
     {
@@ -10778,9 +10778,9 @@
         "text-letter-spacing": 0.08
       },
       "paint": {
-        "text-color": "#5c5f63",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
+        "text-color": "#33373b",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.6
       }
     },
     {
@@ -10842,9 +10842,9 @@
         "text-letter-spacing": 0.08
       },
       "paint": {
-        "text-color": "#5c5f63",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
+        "text-color": "#33373b",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.6
       }
     }
   ]

--- a/public/funges_style_positron.json
+++ b/public/funges_style_positron.json
@@ -1,0 +1,10851 @@
+{
+  "version": 8,
+  "name": "Funges Positron",
+  "metadata": {
+    "maputnik:renderer": "mlgljs",
+    "custom:based_on": "funges_style.json (CARTO recolor)"
+  },
+  "center": [
+    10.679681327683397,
+    59.20531786301794
+  ],
+  "zoom": 5.10124672030565,
+  "bearing": 0,
+  "pitch": 0,
+  "light": {
+    "anchor": "map",
+    "intensity": 0.3,
+    "position": [
+      1.5,
+      235,
+      30
+    ]
+  },
+  "projection": {
+    "type": "mercator"
+  },
+  "sources": {
+    "aws": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/basemap/world_z12_20260619.pmtiles"
+    },
+    "overlay-ne": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/ne_forecast.pmtiles"
+    },
+    "overlay-se": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/se_forecast.pmtiles"
+    },
+    "overlay-use": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/use_forecast.pmtiles"
+    },
+    "overlay-usw": {
+      "type": "vector",
+      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/usw_forecast.pmtiles"
+    }
+  },
+  "sprite": "https://protomaps.github.io/basemaps-assets/sprites/v4/light",
+  "glyphs": "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
+  "created": "0001-01-01T00:00:00Z",
+  "modified": "0001-01-01T00:00:00Z",
+  "id": "hybrid_plus-global-light-default-3.1.0",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#d5dbdd"
+      }
+    },
+    {
+      "id": "earth",
+      "type": "fill",
+      "source": "aws",
+      "source-layer": "earth",
+      "filter": [
+        "==",
+        [
+          "geometry-type"
+        ],
+        "Polygon"
+      ],
+      "paint": {
+        "fill-color": "#fbfbf9"
+      }
+    },
+    {
+      "id": "landuse_green",
+      "type": "fill",
+      "source": "aws",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Polygon"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "forest",
+            "wood",
+            "nature_reserve",
+            "national_park",
+            "protected_area",
+            "park",
+            "grass",
+            "meadow",
+            "scrub",
+            "grassland"
+          ],
+          true,
+          false
+        ]
+      ],
+      "paint": {
+        "fill-color": "#e4e9de",
+        "fill-opacity": 0.6
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "aws",
+      "source-layer": "water",
+      "filter": [
+        "==",
+        [
+          "geometry-type"
+        ],
+        "Polygon"
+      ],
+      "paint": {
+        "fill-color": "#c9d5d9"
+      }
+    },
+    {
+      "id": "waterway",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "water",
+      "minzoom": 9,
+      "filter": [
+        "==",
+        [
+          "geometry-type"
+        ],
+        "LineString"
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#b7c4c9",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          9,
+          0.4,
+          12,
+          1.2
+        ]
+      }
+    },
+    {
+      "id": "road_minor",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "minor_road",
+            "unclassified",
+            "track"
+          ],
+          true,
+          false
+        ],
+        [
+          "!=",
+          [
+            "get",
+            "kind_detail"
+          ],
+          "service"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#efefec",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          11,
+          0.3,
+          12,
+          0.9
+        ]
+      }
+    },
+    {
+      "id": "road_medium",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "secondary",
+            "tertiary"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#eaeae7",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          0.4,
+          12,
+          1.6
+        ]
+      }
+    },
+    {
+      "id": "road_major",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "motorway",
+            "trunk",
+            "primary"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e4e4e0",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0.5,
+          9,
+          1.3,
+          12,
+          3
+        ]
+      }
+    },
+    {
+      "id": "boundary_region",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "boundaries",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "region",
+            "macroregion"
+          ],
+          true,
+          false
+        ],
+        [
+          "match",
+          [
+            "to-number",
+            [
+              "get",
+              "kind_detail"
+            ]
+          ],
+          [
+            3,
+            4
+          ],
+          true,
+          false
+        ],
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#cbcbcb",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          0.4,
+          12,
+          1
+        ],
+        "line-dasharray": [
+          2,
+          2
+        ]
+      }
+    },
+    {
+      "id": "boundary_country",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "boundaries",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "country"
+        ],
+        [
+          "==",
+          [
+            "to-number",
+            [
+              "get",
+              "kind_detail"
+            ]
+          ],
+          2
+        ],
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#b0b0b0",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          1,
+          0.6,
+          6,
+          1.3
+        ]
+      }
+    },
+    {
+      "id": "water_label",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "water",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          10,
+          8,
+          13
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#7d94a3",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_settlement",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "town",
+            "village",
+            "hamlet",
+            "borough",
+            "suburb"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          7,
+          10,
+          12,
+          14
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#5c5f63",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_city",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "locality"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          11,
+          10,
+          16
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#5c5f63",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_region",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "region",
+            "macroregion"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          10,
+          8,
+          13
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#5c5f63",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_country",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "country"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          1,
+          11,
+          4,
+          15
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#5c5f63",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "walnut_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.2)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.2)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.16)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_ne",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.17)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast"
+    },
+    {
+      "id": "mushroom_se",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast"
+    },
+    {
+      "id": "mushroom_use",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.18)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast"
+    },
+    {
+      "id": "mushroom_usw",
+      "type": "fill",
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "hsla(60, 92%, 95%, 0.19)",
+          0.5,
+          "#ffffcc",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "#ffe4b5",
+          3,
+          "#ffdab9",
+          4,
+          "#fec99a",
+          5,
+          "#fbae7e",
+          6,
+          "#fa733d",
+          7,
+          "#fb6d51",
+          8,
+          "#fb4646",
+          9,
+          "#a60310",
+          10,
+          "#800020"
+        ],
+        "fill-opacity": 0.85,
+        "fill-antialias": false
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast"
+    },
+    {
+      "id": "walnut_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "walnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "walnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "walnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "walnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "walnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "walnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "walnut_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "walnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "walnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "walnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "truffle_b_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "truffle_b_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "truffle_b_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "truffle_b_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "truffle_b_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "truffle_b_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "truffle_b_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "truffle_b_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "truffle_b_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "truffle_b_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "strawberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "strawberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "strawberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "strawberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "strawberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "strawberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "strawberry_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "strawberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "strawberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "strawberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "st_george_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "st_george_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "st_george_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "st_george_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "st_george_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "st_george_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "st_george_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "st_george_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "st_george_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "st_george_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "sorrel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "sorrel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "sorrel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "sorrel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "sorrel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "sorrel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "sorrel_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "sorrel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "sorrel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "sorrel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "raspberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "raspberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "raspberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "raspberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "raspberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "raspberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "raspberry_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-width": 40,
+        "text-halo-blur": 2,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "raspberry_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ]
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "raspberry_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "raspberry_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "parasol_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "parasol_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "parasol_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "parasol_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "parasol_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "parasol_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "parasol_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "parasol_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "parasol_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "parasol_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "nettle_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "nettle_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "nettle_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "nettle_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "nettle_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "nettle_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "nettle_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "nettle_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "nettle_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "nettle_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "morel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "morel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "morel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "morel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "morel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "morel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "morel_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "morel_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "morel_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "morel_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "masterwort_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "masterwort_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "masterwort_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "masterwort_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "masterwort_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "masterwort_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "masterwort_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "masterwort_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "masterwort_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "masterwort_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "lingonb_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "lingonb_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "lingonb_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "lingonb_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "lingonb_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "lingonb_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "lingonb_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "lingonb_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "lingonb_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "lingonb_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "garlic_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "garlic_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "garlic_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "garlic_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "garlic_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "garlic_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "garlic_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "garlic_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "garlic_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "garlic_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "dandelion_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "dandelion_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "dandelion_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "dandelion_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "dandelion_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "dandelion_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "dandelion_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "dandelion_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "dandelion_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "dandelion_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chickweed_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chickweed_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chickweed_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chickweed_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chickweed_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chickweed_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chickweed_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chickweed_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chickweed_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chickweed_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chestnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chestnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chestnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chestnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chestnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chestnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chestnut_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chestnut_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chestnut_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chestnut_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "chant_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "black_chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "black_chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "black_chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "black_chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "black_chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "black_chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "black_chant_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "black_chant_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "black_chant_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "black_chant_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "asparagus_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "asparagus_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "asparagus_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "asparagus_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "asparagus_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "asparagus_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "asparagus_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "asparagus_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "asparagus_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "asparagus_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "artichoke_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "artichoke_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "artichoke_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "artichoke_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "artichoke_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "artichoke_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "artichoke_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "artichoke_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "artichoke_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "artichoke_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "amaranth_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "amaranth_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "amaranth_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "amaranth_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "amaranth_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "amaranth_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "amaranth_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "amaranth_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "amaranth_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "amaranth_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_ne_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-ne",
+      "source-layer": "ne_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "mushroom_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "mushroom_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_se_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-se",
+      "source-layer": "se_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "mushroom_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "mushroom_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_use_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-use",
+      "source-layer": "use_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "mushroom_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "mushroom_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    },
+    {
+      "id": "mushroom_usw_numbers",
+      "type": "symbol",
+      "paint": {
+        "text-color": "rgb(0, 0, 0)",
+        "text-opacity": 0.88,
+        "text-halo-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "get",
+            "mushroom_score"
+          ],
+          0,
+          "rgb(254, 254, 230)",
+          1,
+          "rgb(255, 255, 204)",
+          2,
+          "rgb(255, 228, 181)",
+          3,
+          "rgb(255, 218, 185)",
+          4,
+          "rgb(254, 201, 154)",
+          5,
+          "rgb(251, 174, 126)",
+          6,
+          "rgb(250, 115, 61)",
+          7,
+          "rgb(251, 109, 81)",
+          8,
+          "rgb(251, 70, 70)",
+          9,
+          "rgb(166, 3, 16)",
+          10,
+          "rgb(128, 0, 32)"
+        ],
+        "text-halo-width": 40,
+        "text-halo-blur": 2
+      },
+      "source": "overlay-usw",
+      "source-layer": "usw_forecast",
+      "layout": {
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-field": [
+          "case",
+          [
+            "<",
+            [
+              "get",
+              "mushroom_score"
+            ],
+            1
+          ],
+          "",
+          [
+            "to-string",
+            [
+              "floor",
+              [
+                "get",
+                "mushroom_score"
+              ]
+            ]
+          ]
+        ],
+        "text-size": 20,
+        "visibility": "none"
+      }
+    }
+  ]
+}

--- a/public/funges_style_positron.json
+++ b/public/funges_style_positron.json
@@ -167,168 +167,6 @@
       }
     },
     {
-      "id": "road_minor",
-      "type": "line",
-      "source": "aws",
-      "source-layer": "roads",
-      "minzoom": 11,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "LineString"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind"
-          ],
-          [
-            "minor_road",
-            "unclassified",
-            "track"
-          ],
-          true,
-          false
-        ],
-        [
-          "!=",
-          [
-            "get",
-            "kind_detail"
-          ],
-          "service"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#efefec",
-        "line-width": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          11,
-          0.3,
-          12,
-          0.9
-        ]
-      }
-    },
-    {
-      "id": "road_medium",
-      "type": "line",
-      "source": "aws",
-      "source-layer": "roads",
-      "minzoom": 8,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "LineString"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind_detail"
-          ],
-          [
-            "secondary",
-            "tertiary"
-          ],
-          true,
-          false
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#eaeae7",
-        "line-width": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          8,
-          0.4,
-          12,
-          1.6
-        ]
-      }
-    },
-    {
-      "id": "road_major",
-      "type": "line",
-      "source": "aws",
-      "source-layer": "roads",
-      "minzoom": 5,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "LineString"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind_detail"
-          ],
-          [
-            "motorway",
-            "trunk",
-            "primary"
-          ],
-          true,
-          false
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#e4e4e0",
-        "line-width": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          5,
-          0.5,
-          9,
-          1.3,
-          12,
-          3
-        ]
-      }
-    },
-    {
       "id": "boundary_region",
       "type": "line",
       "source": "aws",
@@ -452,331 +290,6 @@
           6,
           1.3
         ]
-      }
-    },
-    {
-      "id": "water_label",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "water",
-      "minzoom": 3,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "has",
-          "name"
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          3,
-          10,
-          8,
-          13
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#7d94a3",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
-      }
-    },
-    {
-      "id": "place_settlement",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "places",
-      "minzoom": 7,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind_detail"
-          ],
-          [
-            "town",
-            "village",
-            "hamlet",
-            "borough",
-            "suburb"
-          ],
-          true,
-          false
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Medium"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          7,
-          10,
-          12,
-          14
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#5c5f63",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
-      }
-    },
-    {
-      "id": "place_city",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "places",
-      "minzoom": 3,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "==",
-          [
-            "get",
-            "kind"
-          ],
-          "locality"
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Medium"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          3,
-          11,
-          10,
-          16
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible",
-        "text-transform": "uppercase",
-        "text-letter-spacing": 0.08
-      },
-      "paint": {
-        "text-color": "#5c5f63",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
-      }
-    },
-    {
-      "id": "place_region",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "places",
-      "minzoom": 4,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "match",
-          [
-            "get",
-            "kind"
-          ],
-          [
-            "region",
-            "macroregion"
-          ],
-          true,
-          false
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          4,
-          10,
-          8,
-          13
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible",
-        "text-transform": "uppercase",
-        "text-letter-spacing": 0.08
-      },
-      "paint": {
-        "text-color": "#5c5f63",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
-      }
-    },
-    {
-      "id": "place_country",
-      "type": "symbol",
-      "source": "aws",
-      "source-layer": "places",
-      "minzoom": 1,
-      "filter": [
-        "all",
-        [
-          "==",
-          [
-            "geometry-type"
-          ],
-          "Point"
-        ],
-        [
-          "==",
-          [
-            "get",
-            "kind"
-          ],
-          "country"
-        ]
-      ],
-      "layout": {
-        "text-field": [
-          "coalesce",
-          [
-            "get",
-            "name:en"
-          ],
-          [
-            "get",
-            "name"
-          ]
-        ],
-        "text-font": [
-          "Noto Sans Medium"
-        ],
-        "text-size": [
-          "interpolate",
-          [
-            "linear"
-          ],
-          [
-            "zoom"
-          ],
-          1,
-          11,
-          4,
-          15
-        ],
-        "text-max-width": 6,
-        "text-padding": 2,
-        "visibility": "visible",
-        "text-transform": "uppercase",
-        "text-letter-spacing": 0.08
-      },
-      "paint": {
-        "text-color": "#5c5f63",
-        "text-halo-color": "#fbfbf9",
-        "text-halo-width": 1.2
       }
     },
     {
@@ -10845,6 +10358,493 @@
         ],
         "text-size": 20,
         "visibility": "none"
+      }
+    },
+    {
+      "id": "road_minor",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "minor_road",
+            "unclassified",
+            "track"
+          ],
+          true,
+          false
+        ],
+        [
+          "!=",
+          [
+            "get",
+            "kind_detail"
+          ],
+          "service"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#efefec",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          11,
+          0.3,
+          12,
+          0.9
+        ]
+      }
+    },
+    {
+      "id": "road_medium",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "secondary",
+            "tertiary"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#eaeae7",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          0.4,
+          12,
+          1.6
+        ]
+      }
+    },
+    {
+      "id": "road_major",
+      "type": "line",
+      "source": "aws",
+      "source-layer": "roads",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "LineString"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "motorway",
+            "trunk",
+            "primary"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#e4e4e0",
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0.5,
+          9,
+          1.3,
+          12,
+          3
+        ]
+      }
+    },
+    {
+      "id": "water_label",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "water",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          10,
+          8,
+          13
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#7d94a3",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_settlement",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind_detail"
+          ],
+          [
+            "town",
+            "village",
+            "hamlet",
+            "borough",
+            "suburb"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          7,
+          10,
+          12,
+          14
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#5c5f63",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_city",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 3,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "locality"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          11,
+          10,
+          16
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#5c5f63",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_region",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 4,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "match",
+          [
+            "get",
+            "kind"
+          ],
+          [
+            "region",
+            "macroregion"
+          ],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          10,
+          8,
+          13
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#5c5f63",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_country",
+      "type": "symbol",
+      "source": "aws",
+      "source-layer": "places",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        [
+          "==",
+          [
+            "geometry-type"
+          ],
+          "Point"
+        ],
+        [
+          "==",
+          [
+            "get",
+            "kind"
+          ],
+          "country"
+        ]
+      ],
+      "layout": {
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Noto Sans Medium"
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          1,
+          11,
+          4,
+          15
+        ],
+        "text-max-width": 6,
+        "text-padding": 2,
+        "visibility": "visible",
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.08
+      },
+      "paint": {
+        "text-color": "#5c5f63",
+        "text-halo-color": "#fbfbf9",
+        "text-halo-width": 1.2
       }
     }
   ]

--- a/scripts/make_carto_styles.py
+++ b/scripts/make_carto_styles.py
@@ -22,7 +22,9 @@ POSITRON = dict(
     water="#c9d5d9", waterway="#b7c4c9",
     boundary_country="#b0b0b0", boundary_region="#cbcbcb",
     road_major="#e4e4e0", road_medium="#eaeae7", road_minor="#efefec",
-    label="#5c5f63", label_halo="#fbfbf9", water_label="#7d94a3",
+    # near-charcoal text + white halo so names stay legible over the light-tan
+    # forecast polygons (medium grey washed out over them)
+    label="#33373b", label_halo="#ffffff", water_label="#6d8595",
     sprite="https://protomaps.github.io/basemaps-assets/sprites/v4/light",
 )
 DARKMATTER = dict(
@@ -66,7 +68,7 @@ def basemap(p):
             "id": id_, "type": "symbol", "source": "aws", "source-layer": sl,
             "minzoom": minz, "filter": filt, "layout": layout,
             "paint": {"text-color": color, "text-halo-color": halo,
-                      "text-halo-width": 1.2},
+                      "text-halo-width": 1.6},
         }
 
     poly = ["==", ["geometry-type"], "Polygon"]

--- a/scripts/make_carto_styles.py
+++ b/scripts/make_carto_styles.py
@@ -158,7 +158,15 @@ def build(theme, out):
     style["sprite"] = theme["sprite"]
     style["metadata"] = {"maputnik:renderer": "mlgljs",
                          "custom:based_on": "funges_style.json (CARTO recolor)"}
-    style["layers"] = basemap(theme) + overlays
+
+    # Match the original ordering: base fills/water/boundaries render BELOW the
+    # forecast overlays; roads and all place labels render ABOVE them, so names
+    # stay legible over the polygons.
+    bm = basemap(theme)
+    above = [L for L in bm
+             if L.get("type") == "symbol" or L.get("source-layer") == "roads"]
+    below = [L for L in bm if L not in above]
+    style["layers"] = below + overlays + above
 
     (ROOT / "public" / out).write_text(
         json.dumps(style, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/scripts/make_carto_styles.py
+++ b/scripts/make_carto_styles.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Generate Positron / Dark-Matter map styles from funges_style.json.
+
+Both new styles reuse the SAME sources + the 168 forecast/species overlay layers
+(the app drives those by id, so they must stay identical). Only the basemap is
+swapped for a minimal CARTO-like layer set, recolored per theme.
+
+Run from repo root:  python scripts/make_carto_styles.py
+Then the files land in public/ (self-hosted, same as funges_style*.json).
+"""
+import json
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+BASE = ROOT / "public" / "funges_style.json"
+
+# CARTO-ish palettes. ocean = background (shows before land tiles / as sea);
+# land = earth fill on top; water = lakes/rivers/ocean polygons.
+POSITRON = dict(
+    name="Funges Positron",
+    ocean="#d5dbdd", land="#fbfbf9", green="#e4e9de",
+    water="#c9d5d9", waterway="#b7c4c9",
+    boundary_country="#b0b0b0", boundary_region="#cbcbcb",
+    road_major="#e4e4e0", road_medium="#eaeae7", road_minor="#efefec",
+    label="#5c5f63", label_halo="#fbfbf9", water_label="#7d94a3",
+    sprite="https://protomaps.github.io/basemaps-assets/sprites/v4/light",
+)
+DARKMATTER = dict(
+    name="Funges Dark Matter",
+    ocean="#0c0f11", land="#111314", green="#161c14",
+    water="#0c0f11", waterway="#1b2327",
+    boundary_country="#2d2d2d", boundary_region="#232323",
+    road_major="#2e2e2e", road_medium="#242424", road_minor="#1c1c1c",
+    label="#a8a8a8", label_halo="#000000", water_label="#5a7280",
+    sprite="https://protomaps.github.io/basemaps-assets/sprites/v4/dark",
+)
+
+NAME = ["coalesce", ["get", "name:en"], ["get", "name"]]
+
+
+def basemap(p):
+    """Minimal Protomaps-v4 basemap for palette p. Source id 'aws' matches ours."""
+
+    def line(id_, sl, filt, color, width, minz=0, dash=None):
+        L = {
+            "id": id_, "type": "line", "source": "aws", "source-layer": sl,
+            "minzoom": minz, "filter": filt,
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {"line-color": color, "line-width": width},
+        }
+        if dash:
+            L["paint"]["line-dasharray"] = dash
+        return L
+
+    def label(id_, sl, filt, size, color, halo, font="Noto Sans Regular",
+              minz=0, upper=False):
+        layout = {
+            "text-field": NAME, "text-font": [font], "text-size": size,
+            "text-max-width": 6, "text-padding": 2, "visibility": "visible",
+        }
+        if upper:
+            layout["text-transform"] = "uppercase"
+            layout["text-letter-spacing"] = 0.08
+        return {
+            "id": id_, "type": "symbol", "source": "aws", "source-layer": sl,
+            "minzoom": minz, "filter": filt, "layout": layout,
+            "paint": {"text-color": color, "text-halo-color": halo,
+                      "text-halo-width": 1.2},
+        }
+
+    poly = ["==", ["geometry-type"], "Polygon"]
+    lstr = ["==", ["geometry-type"], "LineString"]
+    pt = ["==", ["geometry-type"], "Point"]
+    green_kinds = ["forest", "wood", "nature_reserve", "national_park",
+                   "protected_area", "park", "grass", "meadow", "scrub",
+                   "grassland"]
+
+    return [
+        {"id": "background", "type": "background",
+         "paint": {"background-color": p["ocean"]}},
+        {"id": "earth", "type": "fill", "source": "aws", "source-layer": "earth",
+         "filter": poly, "paint": {"fill-color": p["land"]}},
+        {"id": "landuse_green", "type": "fill", "source": "aws",
+         "source-layer": "landuse",
+         "filter": ["all", poly, ["match", ["get", "kind"], green_kinds, True, False]],
+         "paint": {"fill-color": p["green"], "fill-opacity": 0.6}},
+        {"id": "water", "type": "fill", "source": "aws", "source-layer": "water",
+         "filter": poly, "paint": {"fill-color": p["water"]}},
+        line("waterway", "water", lstr, p["waterway"],
+             ["interpolate", ["linear"], ["zoom"], 9, 0.4, 12, 1.2], minz=9),
+
+        # roads: minor -> medium -> major (drawn low to high so majors sit on top)
+        line("road_minor", "roads",
+             ["all", lstr, ["match", ["get", "kind"],
+                            ["minor_road", "unclassified", "track"], True, False],
+              ["!=", ["get", "kind_detail"], "service"]],
+             p["road_minor"], ["interpolate", ["linear"], ["zoom"], 11, 0.3, 12, 0.9],
+             minz=11),
+        line("road_medium", "roads",
+             ["all", lstr, ["match", ["get", "kind_detail"],
+                            ["secondary", "tertiary"], True, False]],
+             p["road_medium"], ["interpolate", ["linear"], ["zoom"], 8, 0.4, 12, 1.6],
+             minz=8),
+        line("road_major", "roads",
+             ["all", lstr, ["match", ["get", "kind_detail"],
+                            ["motorway", "trunk", "primary"], True, False]],
+             p["road_major"], ["interpolate", ["linear"], ["zoom"], 5, 0.5, 9, 1.3, 12, 3],
+             minz=5),
+
+        # admin boundaries
+        line("boundary_region", "boundaries",
+             ["all", ["match", ["get", "kind"], ["region", "macroregion"], True, False],
+              ["match", ["to-number", ["get", "kind_detail"]], [3, 4], True, False], lstr],
+             p["boundary_region"], ["interpolate", ["linear"], ["zoom"], 4, 0.4, 12, 1],
+             minz=4, dash=[2, 2]),
+        line("boundary_country", "boundaries",
+             ["all", ["==", ["get", "kind"], "country"],
+              ["==", ["to-number", ["get", "kind_detail"]], 2], lstr],
+             p["boundary_country"], ["interpolate", ["linear"], ["zoom"], 1, 0.6, 6, 1.3],
+             minz=1),
+
+        # labels
+        label("water_label", "water", ["all", pt, ["has", "name"]],
+              ["interpolate", ["linear"], ["zoom"], 3, 10, 8, 13],
+              p["water_label"], p["label_halo"], minz=3),
+        label("place_settlement", "places",
+              ["all", pt, ["match", ["get", "kind_detail"],
+                           ["town", "village", "hamlet", "borough", "suburb"], True, False]],
+              ["interpolate", ["linear"], ["zoom"], 7, 10, 12, 14],
+              p["label"], p["label_halo"], font="Noto Sans Medium", minz=7),
+        label("place_city", "places",
+              ["all", pt, ["==", ["get", "kind"], "locality"]],
+              ["interpolate", ["linear"], ["zoom"], 3, 11, 10, 16],
+              p["label"], p["label_halo"], font="Noto Sans Medium", minz=3, upper=True),
+        label("place_region", "places",
+              ["all", pt, ["match", ["get", "kind"], ["region", "macroregion"], True, False]],
+              ["interpolate", ["linear"], ["zoom"], 4, 10, 8, 13],
+              p["label"], p["label_halo"], minz=4, upper=True),
+        label("place_country", "places",
+              ["all", pt, ["==", ["get", "kind"], "country"]],
+              ["interpolate", ["linear"], ["zoom"], 1, 11, 4, 15],
+              p["label"], p["label_halo"], font="Noto Sans Medium", minz=1, upper=True),
+    ]
+
+
+def build(theme, out):
+    base = json.loads(BASE.read_text(encoding="utf-8"))
+    overlays = [L for L in base["layers"]
+                if str(L.get("source", "")).startswith("overlay")]
+
+    style = {k: v for k, v in base.items() if k != "layers"}
+    style["name"] = theme["name"]
+    style["sprite"] = theme["sprite"]
+    style["metadata"] = {"maputnik:renderer": "mlgljs",
+                         "custom:based_on": "funges_style.json (CARTO recolor)"}
+    style["layers"] = basemap(theme) + overlays
+
+    (ROOT / "public" / out).write_text(
+        json.dumps(style, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"wrote public/{out}: {len(style['layers'])} layers "
+          f"({len(overlays)} overlays kept)")
+
+
+build(POSITRON, "funges_style_positron.json")
+build(DARKMATTER, "funges_style_darkmatter.json")

--- a/scripts/make_carto_styles.py
+++ b/scripts/make_carto_styles.py
@@ -27,7 +27,8 @@ POSITRON = dict(
 )
 DARKMATTER = dict(
     name="Funges Dark Matter",
-    ocean="#0c0f11", land="#111314", green="#161c14",
+    # green=None -> no vegetation tint; Dark Matter is monochrome (Positron keeps its green)
+    ocean="#0c0f11", land="#111314", green=None,
     water="#0c0f11", waterway="#1b2327",
     boundary_country="#2d2d2d", boundary_region="#232323",
     road_major="#2e2e2e", road_medium="#242424", road_minor="#1c1c1c",
@@ -75,15 +76,19 @@ def basemap(p):
                    "protected_area", "park", "grass", "meadow", "scrub",
                    "grassland"]
 
+    green_layer = [{
+        "id": "landuse_green", "type": "fill", "source": "aws",
+        "source-layer": "landuse",
+        "filter": ["all", poly, ["match", ["get", "kind"], green_kinds, True, False]],
+        "paint": {"fill-color": p["green"], "fill-opacity": 0.6},
+    }] if p.get("green") else []
+
     return [
         {"id": "background", "type": "background",
          "paint": {"background-color": p["ocean"]}},
         {"id": "earth", "type": "fill", "source": "aws", "source-layer": "earth",
          "filter": poly, "paint": {"fill-color": p["land"]}},
-        {"id": "landuse_green", "type": "fill", "source": "aws",
-         "source-layer": "landuse",
-         "filter": ["all", poly, ["match", ["get", "kind"], green_kinds, True, False]],
-         "paint": {"fill-color": p["green"], "fill-opacity": 0.6}},
+        *green_layer,
         {"id": "water", "type": "fill", "source": "aws", "source-layer": "water",
          "filter": poly, "paint": {"fill-color": p["water"]}},
         line("waterway", "water", lstr, p["waterway"],

--- a/src/components/AdvancedMap.tsx
+++ b/src/components/AdvancedMap.tsx
@@ -147,7 +147,7 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
     setUserLocationError,
     setShowUserLocation,
     foragingSpots,
-    toggleDarkLayersVisibility,
+    cycleMapStyle,
     setMapRef,
     updateVisibleLayers,
     restoreDarkLayersState,
@@ -902,9 +902,9 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
             )}
           </motion.button>
 
-          {/* Dark mode toggle */}
+          {/* Map style cycle (light → dark → Positron → Dark Matter) */}
           <motion.button
-            onClick={toggleDarkLayersVisibility}
+            onClick={cycleMapStyle}
             className={`inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors disabled:pointer-events-none disabled:opacity-50 border h-9 px-3 shadow-lg ${
               darkLayersVisible
                 ? 'bg-gray-100 border-gray-300 text-gray-800'

--- a/src/components/AdvancedMap.tsx
+++ b/src/components/AdvancedMap.tsx
@@ -255,6 +255,14 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
         map.current.remove();
         map.current = null;
       }
+      // The new map instance starts unloaded. Resetting this makes mapLoaded go
+      // false->true when the new map fires 'load', which re-runs every
+      // [mapLoaded]-gated effect (route source/layer, offline sources, markers)
+      // against the NEW instance. Without this, a style swap leaves mapLoaded
+      // stuck true, those effects never re-run, and e.g. the route line is never
+      // re-added to the new map — drawing a route shows markers but no line.
+      setMapLoaded(false);
+      setMapRef(null);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapStyle]);

--- a/src/i18n/locales/de/instructions.json
+++ b/src/i18n/locales/de/instructions.json
@@ -14,7 +14,7 @@
     "title": "Funktionen:",
     "recipes": "Zeigt Rezepte in der Nähe und Routen zu Zutatenstopps",
     "location": "Zentriert die Karte auf den Standort des Nutzers",
-    "theme": "Wechsel zwischen Hell- und Dunkelmodus",
+    "theme": "Wechsle durch 4 Kartenstile: Hell, Dunkel, Positron, Dark Matter",
     "numbers": "Zeigt numerische Bewertung an"
   },
   "mapInteraction": {

--- a/src/i18n/locales/de/map.json
+++ b/src/i18n/locales/de/map.json
@@ -58,7 +58,7 @@
   },
   "getLocation": "Meinen Standort ermitteln",
   "toggleNumbers": "Zahlen ein-/ausblenden",
-  "toggleDarkMode": "Dunkelmodus umschalten",
+  "toggleDarkMode": "Kartenstil wechseln",
   "showOnboarding": "Anleitung anzeigen",
   "dataFreshnessTooltip": "Daten werden täglich aktualisiert",
   "featureInfo": {
@@ -73,7 +73,7 @@
       "species": "Wähle eine Art mit dem Selektor",
       "locate": "Zentriere die Karte auf deinen Standort",
       "numbers": "Zeige oder verberge den numerischen Index",
-      "theme": "Wechsle zwischen dunklem und hellem Kartenstil",
+      "theme": "Wechsle durch 4 Kartenstile: Hell, Dunkel, Positron, Dark Matter",
       "zones": "Tippe auf eine Zone, um die Artenliste anzuzeigen",
       "recipes": "Öffne Rezepte in der Nähe und zeichne eine Route zu jedem Zutatenstopp"
     },

--- a/src/i18n/locales/en/instructions.json
+++ b/src/i18n/locales/en/instructions.json
@@ -14,7 +14,7 @@
     "title": "Functions:",
     "recipes": "Shows nearby recipes and routes to ingredient stops",
     "location": "Centres the Map on the User's Location",
-    "theme": "Switch between Light- and Dark-mode",
+    "theme": "Cycle through 4 map styles: Light, Dark, Positron, Dark Matter",
     "numbers": "Displays Numeric Rating"
   },
   "mapInteraction": {

--- a/src/i18n/locales/en/map.json
+++ b/src/i18n/locales/en/map.json
@@ -57,7 +57,7 @@
   },
   "getLocation": "Get My Location",
   "toggleNumbers": "Toggle Numbers",
-  "toggleDarkMode": "Toggle Dark Mode",
+  "toggleDarkMode": "Change map style",
   "showOnboarding": "Show onboarding",
   "dataFreshnessTooltip": "Data refreshed daily",
   "featureInfo": {
@@ -72,7 +72,7 @@
       "species": "Choose a species with the selector",
       "locate": "Center the map on your location",
       "numbers": "Show or hide the numeric index",
-      "theme": "Switch between dark and light map styles",
+      "theme": "Cycle through 4 map styles: Light, Dark, Positron, Dark Matter",
       "zones": "Tap a zone to view its species list",
       "recipes": "Open nearby recipes and draw a route to each ingredient stop"
     },

--- a/src/i18n/locales/es/instructions.json
+++ b/src/i18n/locales/es/instructions.json
@@ -14,7 +14,7 @@
     "title": "Funciones:",
     "recipes": "Muestra recetas cercanas y rutas a las paradas de ingredientes",
     "location": "Centra el mapa en la ubicación del usuario",
-    "theme": "Cambia entre modo claro y oscuro",
+    "theme": "Alterna entre 4 estilos de mapa: Claro, Oscuro, Positron, Dark Matter",
     "numbers": "Muestra la calificación numérica"
   },
   "mapInteraction": {

--- a/src/i18n/locales/es/map.json
+++ b/src/i18n/locales/es/map.json
@@ -58,7 +58,7 @@
   },
   "getLocation": "Obtener mi ubicación",
   "toggleNumbers": "Mostrar números",
-  "toggleDarkMode": "Cambiar a modo oscuro",
+  "toggleDarkMode": "Cambiar estilo de mapa",
   "showOnboarding": "Mostrar instrucciones",
   "dataFreshnessTooltip": "Datos actualizados diariamente",
   "featureInfo": {
@@ -73,7 +73,7 @@
       "species": "Elige una especie con el selector",
       "locate": "Centra el mapa en tu ubicación",
       "numbers": "Muestra u oculta el índice numérico",
-      "theme": "Cambia entre estilos de mapa claro y oscuro",
+      "theme": "Alterna entre 4 estilos de mapa: Claro, Oscuro, Positron, Dark Matter",
       "zones": "Toca una zona para ver la lista de especies",
       "recipes": "Abre recetas cercanas y traza una ruta hasta cada parada de ingredientes"
     },

--- a/src/i18n/locales/fr/instructions.json
+++ b/src/i18n/locales/fr/instructions.json
@@ -14,7 +14,7 @@
     "title": "Fonctions :",
     "recipes": "Affiche les recettes proches et des trajets vers les etapes ingredients",
     "location": "Centre la carte sur la position de l'utilisateur",
-    "theme": "Bascule entre le mode clair et le mode sombre",
+    "theme": "Basculez entre 4 styles de carte : Clair, Sombre, Positron, Dark Matter",
     "numbers": "Affiche la note numérique"
   },
   "mapInteraction": {

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -58,7 +58,7 @@
   },
   "getLocation": "Obtenir ma position",
   "toggleNumbers": "Afficher/masquer les notes",
-  "toggleDarkMode": "Basculer en mode sombre",
+  "toggleDarkMode": "Changer de style de carte",
   "showOnboarding": "Afficher les instructions",
   "dataFreshnessTooltip": "Données mises à jour quotidiennement",
   "featureInfo": {
@@ -73,7 +73,7 @@
       "species": "Choisissez une espèce avec le sélecteur",
       "locate": "Centrer la carte sur votre position",
       "numbers": "Afficher ou masquer l’index numérique",
-      "theme": "Basculer entre les styles de carte clair et sombre",
+      "theme": "Basculez entre 4 styles de carte : Clair, Sombre, Positron, Dark Matter",
       "zones": "Touchez une zone pour voir la liste des espèces",
       "recipes": "Ouvrez les recettes proches et tracez un itineraire vers chaque etape ingredient"
     },

--- a/src/i18n/locales/it/instructions.json
+++ b/src/i18n/locales/it/instructions.json
@@ -14,7 +14,7 @@
     "title": "Funzioni:",
     "recipes": "Mostra ricette vicine e percorsi verso le tappe degli ingredienti",
     "location": "Centra la Mappa sulla Posizione dell'Utente",
-    "theme": "Passa tra Modalità Chiara e Scura",
+    "theme": "Scorri tra 4 stili di mappa: Chiaro, Scuro, Positron, Dark Matter",
     "numbers": "Mostra Valutazione Numerica"
   },
   "mapInteraction": {

--- a/src/i18n/locales/it/map.json
+++ b/src/i18n/locales/it/map.json
@@ -57,7 +57,7 @@
   },
   "getLocation": "Ottieni la Mia Posizione",
   "toggleNumbers": "Attiva/Disattiva Numeri",
-  "toggleDarkMode": "Attiva/Disattiva Modalità Scura",
+  "toggleDarkMode": "Cambia stile mappa",
   "showOnboarding": "Mostra istruzioni",
   "dataFreshnessTooltip": "Dati aggiornati quotidianamente",
   "featureInfo": {
@@ -72,7 +72,7 @@
       "species": "Scegli una specie con il selettore",
       "locate": "Centra la mappa sulla tua posizione",
       "numbers": "Mostra o nascondi l’indice numerico",
-      "theme": "Passa tra lo stile chiaro e scuro della mappa",
+      "theme": "Scorri tra 4 stili di mappa: Chiaro, Scuro, Positron, Dark Matter",
       "zones": "Tocca una zona per vedere l’elenco delle specie",
       "recipes": "Apri le ricette vicine e traccia un percorso verso ogni tappa degli ingredienti"
     },

--- a/src/i18n/locales/pt/instructions.json
+++ b/src/i18n/locales/pt/instructions.json
@@ -14,7 +14,7 @@
     "title": "Funções:",
     "recipes": "Exibe receitas proximas e rotas para as paradas de ingredientes",
     "location": "Centraliza o mapa na localização do usuário",
-    "theme": "Alterna entre modo claro e escuro",
+    "theme": "Alterne entre 4 estilos de mapa: Claro, Escuro, Positron, Dark Matter",
     "numbers": "Exibe classificação numérica"
   },
   "mapInteraction": {

--- a/src/i18n/locales/pt/map.json
+++ b/src/i18n/locales/pt/map.json
@@ -58,7 +58,7 @@
   },
   "getLocation": "Obter minha localização",
   "toggleNumbers": "Alternar números",
-  "toggleDarkMode": "Alternar modo escuro",
+  "toggleDarkMode": "Mudar estilo do mapa",
   "showOnboarding": "Mostrar instruções",
   "dataFreshnessTooltip": "Dados atualizados diariamente",
   "featureInfo": {
@@ -73,7 +73,7 @@
       "species": "Escolha uma espécie com o seletor",
       "locate": "Centralize o mapa na sua localização",
       "numbers": "Mostrar ou ocultar o índice numérico",
-      "theme": "Alternar entre estilos de mapa claro e escuro",
+      "theme": "Alterne entre 4 estilos de mapa: Claro, Escuro, Positron, Dark Matter",
       "zones": "Toque em uma zona para ver a lista de espécies",
       "recipes": "Abra receitas proximas e trace uma rota ate cada parada de ingredientes"
     },

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -48,7 +48,8 @@ export interface MapState {
   speciesDisplayMap: Record<string, string>;
 
   // Layer visibility
-  darkLayersVisible: boolean;
+  darkLayersVisible: boolean; // true when the active style is a dark one
+  mapStyleIndex: number; // index into MAP_STYLES (cycled by the style button)
   numbersLayersVisible: boolean;
   activeDay: number; // 0 = today; 1..6 = forecast
 
@@ -82,7 +83,7 @@ export interface MapState {
 
   // Species selection actions
   setSelectedSpecies: (species: string | null) => void;
-  toggleDarkLayersVisibility: () => void;
+  cycleMapStyle: () => void;
   toggleNumbersLayersVisibility: () => void;
   setActiveDay: (day: number) => void;
 
@@ -92,11 +93,26 @@ export interface MapState {
   restoreDarkLayersState: () => void;
 }
 
-// Dark mode swaps the whole style — Protomaps basemap has no per-layer ` dark` variant.
-// Both styles carry the same overlay layers; AdvancedMap's [mapStyle] effect recreates
-// the map (camera preserved from the store) and re-applies species visibility on swap.
-const LIGHT_STYLE = '/funges_style.json';
-const DARK_STYLE = '/funges_style_dark.json';
+// The map-style button cycles these 4 whole styles — Protomaps basemap has no
+// per-layer ` dark` variant. All 4 carry the SAME overlay/species layers (only the
+// basemap differs); AdvancedMap's [mapStyle] effect recreates the map (camera
+// preserved from the store) and re-applies species visibility on swap.
+// Regenerate positron/darkmatter via scripts/make_carto_styles.py.
+const MAP_STYLES = [
+  '/funges_style.json', // 0 light (olive)
+  '/funges_style_dark.json', // 1 dark
+  '/funges_style_positron.json', // 2 Positron
+  '/funges_style_darkmatter.json', // 3 Dark Matter
+];
+const DARK_STYLE_INDEXES = new Set([1, 3]); // drives the button's dark styling
+function readStyleIndex(): number {
+  const saved = Number(localStorage.getItem('mapStyleIndex'));
+  if (Number.isInteger(saved) && saved >= 0 && saved < MAP_STYLES.length) {
+    return saved;
+  }
+  // Back-compat with the old light/dark boolean.
+  return localStorage.getItem('darkLayersVisible') === 'true' ? 1 : 0;
+}
 
 // Region overlay/forecast tilesets are heavy; keeping all four live at once (even when
 // only one is in view) is what makes the map lag. We only show a region's layers when
@@ -147,10 +163,8 @@ export const useMapStore = create<MapState>()(
       zoom: 3.5,
       bearing: 0,
       pitch: 0,
-      mapStyle:
-        localStorage.getItem('darkLayersVisible') === 'true'
-          ? DARK_STYLE
-          : LIGHT_STYLE, // self-hosted from public/; regenerate via scripts/add-overlay-to-style.cjs then re-copy
+      mapStyle: MAP_STYLES[readStyleIndex()], // self-hosted from public/
+      mapStyleIndex: readStyleIndex(),
       userLocation: null,
       userLocationError: null,
       foragingSpots: [],
@@ -160,7 +174,7 @@ export const useMapStore = create<MapState>()(
       speciesDisplayMap: {
         // This will be programmatically generated from speciesOptions and species.json
       },
-      darkLayersVisible: localStorage.getItem('darkLayersVisible') === 'true',
+      darkLayersVisible: DARK_STYLE_INDEXES.has(readStyleIndex()),
       // ponytail: numbers layer temporarily disabled (glyph flood janks the map). The
       // toggle button + instruction entries are removed but the layers/logic stay wired;
       // re-enable by restoring the button and this localStorage read.
@@ -196,14 +210,15 @@ export const useMapStore = create<MapState>()(
         set({ selectedSpecies });
       },
 
-      toggleDarkLayersVisibility: () =>
+      cycleMapStyle: () =>
         set(state => {
-          const darkLayersVisible = !state.darkLayersVisible;
-          localStorage.setItem('darkLayersVisible', String(darkLayersVisible));
+          const mapStyleIndex = (state.mapStyleIndex + 1) % MAP_STYLES.length;
+          localStorage.setItem('mapStyleIndex', String(mapStyleIndex));
           // Swap the style URL; the [mapStyle] effect in AdvancedMap reloads the map.
           return {
-            darkLayersVisible,
-            mapStyle: darkLayersVisible ? DARK_STYLE : LIGHT_STYLE,
+            mapStyleIndex,
+            mapStyle: MAP_STYLES[mapStyleIndex],
+            darkLayersVisible: DARK_STYLE_INDEXES.has(mapStyleIndex),
           };
         }),
       toggleNumbersLayersVisibility: () =>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -123,12 +123,12 @@ export default defineConfig({
           // Map style JSON — required to initialize the map. Cached on the
           // online visit so a downloaded region can still render the map offline.
           {
-            urlPattern: /funges_style(_dark)?\.json$/i,
+            urlPattern: /funges_style(_dark|_positron|_darkmatter)?\.json$/i,
             handler: 'StaleWhileRevalidate',
             options: {
               cacheName: 'map-style-cache',
               expiration: {
-                maxEntries: 4,
+                maxEntries: 6,
                 maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
               },
             },


### PR DESCRIPTION
## Summary
- Two new self-hosted map styles — **Positron** (light) and **Dark Matter** (dark) — generated from `funges_style.json` via `scripts/make_carto_styles.py`. Minimal CARTO-like basemap; the 168 forecast/species overlay layers are reused verbatim (app drives them by id).
- The map-style button now **cycles 4 styles**: Light → Dark → Positron → Dark Matter (index persisted in localStorage, back-compat with the old boolean). SW cache regex + instruction/button copy updated across all 6 locales.

## Fixes in this branch
- **Route line vanished after a style switch** — the `[mapStyle]` teardown never reset `mapLoaded`, so `[mapLoaded]`-gated setup (route source/layer) never re-ran on the recreated map. Reset it in teardown.
- **Dark Matter**: dropped the green vegetation tint (monochrome, like real Dark Matter).
- **Both new styles**: place labels/roads now render above the forecast overlays, like the original.
- **Positron**: darkened label text so names stay legible over the tan overlay polygons.

## Checks
`gl-style-validate` VALID (both) · `tsc` clean · 39 unit tests pass · CI-equivalent LF eslint clean.