### PR TITLE
Add upload key fingerprint to assetlinks.json

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -5,8 +5,7 @@
       "namespace": "android_app",
       "package_name": "es.fung.app",
       "sha256_cert_fingerprints": [
-        "REPLACE_WITH_UPLOAD_KEY_SHA256",
-        "REPLACE_WITH_PLAY_APP_SIGNING_SHA256"
+        "99:F4:38:A7:B4:9D:17:EE:EB:16:EE:66:73:01:0C:2C:38:56:C2:49:C0:37:D9:CB:BC:D7:DF:CB:9B:43:64:C6"
       ]
     }
   }


### PR DESCRIPTION
Fills in the first of the two Digital Asset Links fingerprints with the real SHA-256 of the Bubblewrap upload key (`99:F4:38:...:64:C6`), extracted from the signed APK via `apksigner verify --print-certs`.

With this deployed, the sideloaded `app-release-signed.apk` verifies its asset link and launches without a browser URL bar — which is the check that the whole TWA setup is correct, before touching Play Console.

The `REPLACE_WITH_PLAY_APP_SIGNING_SHA256` placeholder is removed rather than left in place: a non-hex string in `sha256_cert_fingerprints` risks invalidating the entire statement, taking the valid fingerprint down with it. Google's app signing fingerprint gets appended in a follow-up once the first `.aab` is uploaded — both are needed long-term, since users' devices see Google's re-signed build while local test builds carry the upload key.

JSON validated and prettier clean. No source changes, so lint/type-check/tests are unaffected.