### PR TITLE
Add Play signing fingerprint

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "es.fung.app",
       "sha256_cert_fingerprints": [
-        "99:F4:38:A7:B4:9D:17:EE:EB:16:EE:66:73:01:0C:2C:38:56:C2:49:C0:37:D9:CB:BC:D7:DF:CB:9B:43:64:C6"
+        "99:F4:38:A7:B4:9D:17:EE:EB:16:EE:66:73:01:0C:2C:38:56:C2:49:C0:37:D9:CB:BC:D7:DF:CB:9B:43:64:C6",
+        "D6:40:87:72:23:FC:18:63:43:56:19:38:AC:2E:89:DE:8C:87:13:7A:42:14:E6:FF:8F:20:8D:CA:61:54:DA:16"
       ]
     }
   }


### PR DESCRIPTION
## What changed

- Added the Google Play-managed app-signing SHA-256 certificate fingerprint to the Digital Asset Links declaration.
- Retained the existing upload-key fingerprint for locally signed builds.

## Why

Google Play re-signs distributed Android bundles. The production signing certificate must be declared for `es.fung.app` so Play-installed TWA builds can verify ownership of `www.fung.es` and launch without Custom Tab browser chrome.

## User impact

Play-installed Funges builds can verify the website/app relationship and open as a trusted full-screen web activity.

## Validation

- Parsed `assetlinks.json` successfully.
- `npx.cmd prettier --check public/.well-known/assetlinks.json`