### PR TITLE
Adjust splash and map loader sizing

### DIFF
--- a/src/components/AdvancedMap.tsx
+++ b/src/components/AdvancedMap.tsx
@@ -906,7 +906,7 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
               <img
                 src={LoadingSquirrel}
                 alt='Loading...'
-                className='h-80 w-80'
+                className='h-[13.4rem] w-[13.4rem]'
               />
             </div>
           </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,7 +35,7 @@ createRoot(document.getElementById('root')!).render(
 
 // React mounts immediately behind the inline overlay, so map and data loading
 // overlap with the deliberate startup transition instead of waiting for it.
-// Start after a paint opportunity to guarantee 750 ms of visible wordmark even
+// Start after a paint opportunity to guarantee 1000 ms of visible wordmark even
 // when the module is already cached.
 const splash = document.getElementById('app-splash');
-requestAnimationFrame(() => window.setTimeout(() => splash?.remove(), 750));
+requestAnimationFrame(() => window.setTimeout(() => splash?.remove(), 1000));


### PR DESCRIPTION
## What changed

- Increase the FUNGES startup overlay from 750 ms to 1 second.
- Keep React, map, and data initialization running behind the overlay.
- Reduce the map-style loading squirrel from 320 px to approximately 214 px, a 33% reduction.

## Why

The startup wordmark needs a slightly longer intentional display, while the animated squirrel shown during map-style changes currently dominates the map.

## Impact

Startup remains non-blocking and the map-style transition loader is less visually intrusive.

## Validation

- Focused ESLint: passed
- TypeScript: passed
- Production Vite/PWA build: passed