### PR TITLE
Remove splash loading text

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,9 +171,6 @@
       >
         FUNGES
       </div>
-      <div style="font-size: 0.875rem; color: #6b6259">
-        Loading the foraging map…
-      </div>
     </div>
     <div id="root"></div>
     <script type="module" src="src/main.tsx"></script>


### PR DESCRIPTION
## What changed

- Remove “Loading the foraging map…” from the startup overlay.
- Keep the FUNGES wordmark unchanged as the only visible splash content.
- Preserve the existing one-second display duration and background app initialization.

## Why

The loading sentence is unnecessary; the cleaner splash should show only the FUNGES wordmark.

## Validation

- Prettier: passed
- TypeScript: passed
- Production Vite/PWA build: passed