### PR TITLE
Keep precise location on device

### DIFF
--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -80,7 +80,6 @@ export interface MapState {
   setShowUserLocation: (show: boolean) => void;
   clearError: () => void;
   getUserLocation: () => Promise<GeolocationPosition>;
-  fetchNearbySpots: (coordinates: [number, number]) => Promise<void>;
 
   // Species selection actions
   setSelectedSpecies: (species: string | null) => void;
@@ -260,20 +259,12 @@ export const useMapStore = create<MapState>()(
           }
 
           navigator.geolocation.getCurrentPosition(
-            async position => {
+            position => {
               const coords: [number, number] = [
                 position.coords.longitude,
                 position.coords.latitude,
               ];
               set({ userLocation: coords, userLocationError: null });
-
-              // Automatically fetch nearby foraging spots when user gets location
-              try {
-                await get().fetchNearbySpots(coords);
-              } catch (error) {
-                console.warn('Failed to fetch nearby foraging spots:', error);
-                // Don't reject the main promise for this, just log the warning
-              }
 
               resolve(position);
             },
@@ -289,36 +280,6 @@ export const useMapStore = create<MapState>()(
             }
           );
         });
-      },
-
-      fetchNearbySpots: async coordinates => {
-        set({ isLoading: true, error: null });
-        try {
-          // Use the API function to fetch nearby spots
-          const { api } = await import('@/lib/api');
-          const apiSpots = await api.map.getNearbySpots(coordinates, 10); // 10km radius
-
-          // Transform API spots to match our interface
-          const spots: ForagingSpot[] = apiSpots.map(spot => ({
-            id: spot.id,
-            name: spot.name,
-            description: spot.description,
-            coordinates: spot.coordinates,
-            type:
-              spot.species.includes('chant') || spot.species.includes('morel')
-                ? 'mushroom'
-                : 'berry',
-            season: spot.seasonality,
-            confidence: 0.8, // Default confidence
-            lastUpdated: new Date().toISOString(),
-          }));
-
-          set({ foragingSpots: spots, isLoading: false });
-        } catch (error) {
-          // Don't set an error for this background operation, just log it
-          console.warn('Failed to fetch nearby foraging spots:', error);
-          set({ isLoading: false });
-        }
       },
 
       // Foraging spot actions

--- a/src/test/mapStore.test.ts
+++ b/src/test/mapStore.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { layerRegion, resolveDataNerdRegion } from '@/store/mapStore';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  layerRegion,
+  resolveDataNerdRegion,
+  useMapStore,
+} from '@/store/mapStore';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('layerRegion', () => {
   it.each([
@@ -30,5 +38,32 @@ describe('resolveDataNerdRegion', () => {
 
   it('returns null for an unrecognized layer id (no false-positive region match)', () => {
     expect(resolveDataNerdRegion('background')).toBeNull();
+  });
+});
+
+describe('getUserLocation', () => {
+  it('keeps precise coordinates on-device', async () => {
+    const position = {
+      coords: {
+        latitude: 47.7508,
+        longitude: 7.3359,
+      },
+    } as GeolocationPosition;
+    const fetchSpy = vi.fn();
+
+    vi.stubGlobal('fetch', fetchSpy);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      geolocation: {
+        getCurrentPosition: vi.fn(success => success(position)),
+      },
+    });
+
+    await expect(useMapStore.getState().getUserLocation()).resolves.toBe(
+      position
+    );
+
+    expect(useMapStore.getState().userLocation).toEqual([7.3359, 47.7508]);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changed

- Removed the API request that sent precise GPS coordinates to `api.fung.es`.
- Kept location handling on-device for map centring and nearby-feature lookup.
- Removed the now-unused `fetchNearbySpots` store action.
- Added a regression test confirming that geolocation performs no network request.

## Why

The app’s privacy policy states that precise location remains on the user’s device. However, the location workflow also sent latitude and longitude to the nearby-spots API.

The map already searches its loaded features locally, making the remote request redundant.

## User impact

Users retain the same location and map functionality, while their precise coordinates no longer leave their device.

This also aligns the app’s behaviour with its privacy policy and Google Play Data Safety declaration.

## Validation

- Production build passed
- 247 unit tests passed
- TypeScript type-check passed
- Changed-file ESLint and Prettier checks passed

The repository-wide lint command still reports pre-existing CRLF line-ending errors in unrelated files on Windows.