### PR TITLE
Use Funges logo on startup splash

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="icons/logo_1.png" />
+    <link
+      rel="preload"
+      as="image"
+      href="icons/logo_funges.png"
+      type="image/png"
+      fetchpriority="high"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <title>Fung.es - Mushroom Foraging App</title>
@@ -161,16 +168,18 @@
           sans-serif;
       "
     >
-      <div
+      <img
+        src="icons/logo_funges.png"
+        alt="Funges"
+        width="1200"
+        height="504"
         style="
-          font-size: clamp(2rem, 12vw, 4rem);
-          font-weight: 800;
-          letter-spacing: 0.08em;
-          color: #b81c00;
+          display: block;
+          width: min(80vw, 320px);
+          height: auto;
+          object-fit: contain;
         "
-      >
-        FUNGES
-      </div>
+      />
     </div>
     <div id="root"></div>
     <script type="module" src="src/main.tsx"></script>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,7 +35,7 @@ createRoot(document.getElementById('root')!).render(
 
 // React mounts immediately behind the inline overlay, so map and data loading
 // overlap with the deliberate startup transition instead of waiting for it.
-// Start after a paint opportunity to guarantee 1000 ms of visible wordmark even
-// when the module is already cached.
+// Start after a paint opportunity to guarantee 1000 ms of visible brand lockup
+// even when the module is already cached.
 const splash = document.getElementById('app-splash');
 requestAnimationFrame(() => window.setTimeout(() => splash?.remove(), 1000));


### PR DESCRIPTION
## Summary

- replace the plain FUNGES startup text with the existing branded logo and wordmark
- preload the logo with high priority to avoid a blank flash
- preserve the one-second splash while the application loads behind it
- reserve the image dimensions to prevent layout movement

## Validation

- 247 unit tests passed
- production TypeScript/Vite/PWA build passed
- targeted ESLint and Prettier checks passed