### PR TITLE
Use R2 custom domain for production data

### DIFF
--- a/.env
+++ b/.env
@@ -1,51 +1,51 @@
 # Europe
-EU_STATIC_INFO=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/EU_static_info.csv
-EU_ZONE_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/EU_zone_season_curves.json
+EU_STATIC_INFO=https://data.fung.es/EU/EU_static_info.csv
+EU_ZONE_SEASON_CURVES=https://data.fung.es/EU/EU_zone_season_curves.json
 
 # North Europe
-NE_WEATHER_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_weather_data.parquet
-NE_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_season_curves.json
-NE_BASE_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_base_coarse.csv
-NE_BOUNDARIES_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_boundaries.geojson
-NE_CLIPPED_GPKG=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_clipped_triangles_wilderness.gpkg
-NE_SPECIES_PARAMS=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_species_params.txt
-NE_UNIQUE_COORDINATES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_unique_coordinates_coarse.json
-NE_WILDERNESS_DATA_SOURCE=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_wilderness_data.geojson
-NE_MBTILES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/ne_mushroom_data.mbtiles
+NE_WEATHER_DATA=https://data.fung.es/EU/NE/NE_weather_data.parquet
+NE_SEASON_CURVES=https://data.fung.es/EU/NE/NE_season_curves.json
+NE_BASE_DATA=https://data.fung.es/EU/NE/NE_base_coarse.csv
+NE_BOUNDARIES_DATA=https://data.fung.es/EU/NE/NE_boundaries.geojson
+NE_CLIPPED_GPKG=https://data.fung.es/EU/NE/NE_clipped_triangles_wilderness.gpkg
+NE_SPECIES_PARAMS=https://data.fung.es/EU/NE/NE_species_params.txt
+NE_UNIQUE_COORDINATES=https://data.fung.es/EU/NE/NE_unique_coordinates_coarse.json
+NE_WILDERNESS_DATA_SOURCE=https://data.fung.es/EU/NE/NE_wilderness_data.geojson
+NE_MBTILES=https://data.fung.es/EU/NE/ne_mushroom_data.mbtiles
 
 # South Europe
-SE_WEATHER_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_weather_data.parquet
-SE_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_season_curves.json
-SE_BASE_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_base_coarse.csv
-SE_BOUNDARIES_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_boundaries.geojson
-SE_CLIPPED_GPKG=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_clipped_triangles_wilderness.gpkg
-SE_SPECIES_PARAMS=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_species_params.txt
-SE_UNIQUE_COORDINATES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_unique_coordinates_coarse.json
-SE_WILDERNESS_DATA_SOURCE=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_wilderness_data.geojson
-SE_MBTILES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/se_mushroom_data.mbtiles
+SE_WEATHER_DATA=https://data.fung.es/EU/SE/SE_weather_data.parquet
+SE_SEASON_CURVES=https://data.fung.es/EU/SE/SE_season_curves.json
+SE_BASE_DATA=https://data.fung.es/EU/SE/SE_base_coarse.csv
+SE_BOUNDARIES_DATA=https://data.fung.es/EU/SE/SE_boundaries.geojson
+SE_CLIPPED_GPKG=https://data.fung.es/EU/SE/SE_clipped_triangles_wilderness.gpkg
+SE_SPECIES_PARAMS=https://data.fung.es/EU/SE/SE_species_params.txt
+SE_UNIQUE_COORDINATES=https://data.fung.es/EU/SE/SE_unique_coordinates_coarse.json
+SE_WILDERNESS_DATA_SOURCE=https://data.fung.es/EU/SE/SE_wilderness_data.geojson
+SE_MBTILES=https://data.fung.es/EU/SE/se_mushroom_data.mbtiles
 
 # USA
-US_STATIC_INFO=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/US_static_info.csv
-US_ZONE_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/US_zone_season_curves.json
+US_STATIC_INFO=https://data.fung.es/USA/US_static_info.csv
+US_ZONE_SEASON_CURVES=https://data.fung.es/USA/US_zone_season_curves.json
 
 # US East
-USE_WEATHER_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_weather_data.parquet
-USE_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_season_curves.json
-USE_BASE_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_base_coarse.csv
-USE_BOUNDARIES_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_boundaries.geojson
-USE_CLIPPED_GPKG=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_clipped_triangles_wilderness.gpkg
-USE_SPECIES_PARAMS=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_species_params.txt
-USE_UNIQUE_COORDINATES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_unique_coordinates_coarse.json
-USE_WILDERNESS_DATA_SOURCE=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_wilderness_data.geojson
-USE_MBTILES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/use_mushroom_data.mbtiles
+USE_WEATHER_DATA=https://data.fung.es/USA/USE/USE_weather_data.parquet
+USE_SEASON_CURVES=https://data.fung.es/USA/USE/USE_season_curves.json
+USE_BASE_DATA=https://data.fung.es/USA/USE/USE_base_coarse.csv
+USE_BOUNDARIES_DATA=https://data.fung.es/USA/USE/USE_boundaries.geojson
+USE_CLIPPED_GPKG=https://data.fung.es/USA/USE/USE_clipped_triangles_wilderness.gpkg
+USE_SPECIES_PARAMS=https://data.fung.es/USA/USE/USE_species_params.txt
+USE_UNIQUE_COORDINATES=https://data.fung.es/USA/USE/USE_unique_coordinates_coarse.json
+USE_WILDERNESS_DATA_SOURCE=https://data.fung.es/USA/USE/USE_wilderness_data.geojson
+USE_MBTILES=https://data.fung.es/USA/USE/use_mushroom_data.mbtiles
 
 # US West
-USW_WEATHER_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_weather_data.parquet
-USW_SEASON_CURVES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_season_curves.json
-USW_BASE_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_base_coarse.csv
-USW_BOUNDARIES_DATA=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_boundaries.geojson
-USW_CLIPPED_GPKG=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_clipped_triangles_wilderness.gpkg
-USW_SPECIES_PARAMS=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_species_params.txt
-USW_UNIQUE_COORDINATES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_unique_coordinates_coarse.json
-USW_WILDERNESS_DATA_SOURCE=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_wilderness_data.geojson
-USW_MBTILES=https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/usw_mushroom_data.mbtiles
+USW_WEATHER_DATA=https://data.fung.es/USA/USW/USW_weather_data.parquet
+USW_SEASON_CURVES=https://data.fung.es/USA/USW/USW_season_curves.json
+USW_BASE_DATA=https://data.fung.es/USA/USW/USW_base_coarse.csv
+USW_BOUNDARIES_DATA=https://data.fung.es/USA/USW/USW_boundaries.geojson
+USW_CLIPPED_GPKG=https://data.fung.es/USA/USW/USW_clipped_triangles_wilderness.gpkg
+USW_SPECIES_PARAMS=https://data.fung.es/USA/USW/USW_species_params.txt
+USW_UNIQUE_COORDINATES=https://data.fung.es/USA/USW/USW_unique_coordinates_coarse.json
+USW_WILDERNESS_DATA_SOURCE=https://data.fung.es/USA/USW/USW_wilderness_data.geojson
+USW_MBTILES=https://data.fung.es/USA/USW/usw_mushroom_data.mbtiles

--- a/backend/tools/bioclip_export.py
+++ b/backend/tools/bioclip_export.py
@@ -31,7 +31,7 @@ from bioclip_spike import (  # noqa: E402
     taxonomic_prompt,
 )
 
-R2 = "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev"
+R2 = "https://data.fung.es"
 
 ARTIFACTS = Path(__file__).resolve().parent / "model_artifacts"
 ONNX_FP32 = ARTIFACTS / "image_tower_fp32.onnx"

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     <!-- Map data + glyph origins: DNS/TLS handshake overlaps the JS download -->
     <link
       rel="preconnect"
-      href="https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev"
+      href="https://data.fung.es"
       crossorigin
     />
     <link rel="preconnect" href="https://protomaps.github.io" crossorigin />

--- a/public/funges_style.json
+++ b/public/funges_style.json
@@ -47,23 +47,23 @@
   "sources": {
     "aws": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/basemap/world_z12_20260619.pmtiles"
+      "url": "pmtiles://https://data.fung.es/basemap/world_z12_20260619.pmtiles"
     },
     "overlay-ne": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/ne_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/NE/ne_forecast.pmtiles"
     },
     "overlay-se": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/se_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/SE/se_forecast.pmtiles"
     },
     "overlay-use": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/use_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USE/use_forecast.pmtiles"
     },
     "overlay-usw": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/usw_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USW/usw_forecast.pmtiles"
     }
   },
   "sprite": "https://protomaps.github.io/basemaps-assets/sprites/v4/light",

--- a/public/funges_style_dark.json
+++ b/public/funges_style_dark.json
@@ -47,23 +47,23 @@
   "sources": {
     "aws": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/basemap/world_z12_20260619.pmtiles"
+      "url": "pmtiles://https://data.fung.es/basemap/world_z12_20260619.pmtiles"
     },
     "overlay-ne": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/ne_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/NE/ne_forecast.pmtiles"
     },
     "overlay-se": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/se_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/SE/se_forecast.pmtiles"
     },
     "overlay-use": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/use_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USE/use_forecast.pmtiles"
     },
     "overlay-usw": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/usw_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USW/usw_forecast.pmtiles"
     }
   },
   "sprite": "https://protomaps.github.io/basemaps-assets/sprites/v4/light",

--- a/public/funges_style_darkmatter.json
+++ b/public/funges_style_darkmatter.json
@@ -27,23 +27,23 @@
   "sources": {
     "aws": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/basemap/world_z12_20260619.pmtiles"
+      "url": "pmtiles://https://data.fung.es/basemap/world_z12_20260619.pmtiles"
     },
     "overlay-ne": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/ne_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/NE/ne_forecast.pmtiles"
     },
     "overlay-se": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/se_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/SE/se_forecast.pmtiles"
     },
     "overlay-use": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/use_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USE/use_forecast.pmtiles"
     },
     "overlay-usw": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/usw_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USW/usw_forecast.pmtiles"
     }
   },
   "sprite": "https://protomaps.github.io/basemaps-assets/sprites/v4/dark",

--- a/public/funges_style_positron.json
+++ b/public/funges_style_positron.json
@@ -27,23 +27,23 @@
   "sources": {
     "aws": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/basemap/world_z12_20260619.pmtiles"
+      "url": "pmtiles://https://data.fung.es/basemap/world_z12_20260619.pmtiles"
     },
     "overlay-ne": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/ne_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/NE/ne_forecast.pmtiles"
     },
     "overlay-se": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/se_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/SE/se_forecast.pmtiles"
     },
     "overlay-use": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/use_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USE/use_forecast.pmtiles"
     },
     "overlay-usw": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/usw_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USW/usw_forecast.pmtiles"
     }
   },
   "sprite": "https://protomaps.github.io/basemaps-assets/sprites/v4/light",

--- a/public/funges_style_topographic.json
+++ b/public/funges_style_topographic.json
@@ -27,23 +27,23 @@
   "sources": {
     "aws": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/basemap/world_z12_20260619.pmtiles"
+      "url": "pmtiles://https://data.fung.es/basemap/world_z12_20260619.pmtiles"
     },
     "overlay-ne": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/ne_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/NE/ne_forecast.pmtiles"
     },
     "overlay-se": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/se_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/EU/SE/se_forecast.pmtiles"
     },
     "overlay-use": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/use_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USE/use_forecast.pmtiles"
     },
     "overlay-usw": {
       "type": "vector",
-      "url": "pmtiles://https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/usw_forecast.pmtiles"
+      "url": "pmtiles://https://data.fung.es/USA/USW/usw_forecast.pmtiles"
     }
   },
   "sprite": "https://protomaps.github.io/basemaps-assets/sprites/v4/light",

--- a/scripts/add-overlay-to-style.cjs
+++ b/scripts/add-overlay-to-style.cjs
@@ -15,7 +15,7 @@ const livePath = process.argv[2];
 const stylePath = process.argv[3] || 'public/funges_style.json';
 if (!livePath) { console.error('need <live_style.json>'); process.exit(1); }
 
-const R2 = 'https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev';
+const R2 = 'https://data.fung.es';
 // current source-layer in live style -> [new source id, new pmtiles url, new source-layer]
 const REGION = {
   'ne-scores':  ['overlay-ne',  `${R2}/EU/NE/ne_forecast.pmtiles`,   'ne_forecast'],

--- a/scripts/generate_data.py
+++ b/scripts/generate_data.py
@@ -19,10 +19,10 @@ import pandas as pd
 import requests
 
 REGION_URLS: dict[str, str] = {
-    "NE": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_weather_data.parquet",
-    "SE": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_weather_data.parquet",
-    "USE": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_weather_data.parquet",
-    "USW": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_weather_data.parquet",
+    "NE": "https://data.fung.es/EU/NE/NE_weather_data.parquet",
+    "SE": "https://data.fung.es/EU/SE/SE_weather_data.parquet",
+    "USE": "https://data.fung.es/USA/USE/USE_weather_data.parquet",
+    "USW": "https://data.fung.es/USA/USW/USW_weather_data.parquet",
 }
 
 REGION_LABELS: dict[str, str] = {

--- a/scripts/qa_gbif_scores.py
+++ b/scripts/qa_gbif_scores.py
@@ -27,7 +27,7 @@ import requests
 from scipy.spatial import cKDTree
 
 
-R2_ROOT = "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev"
+R2_ROOT = "https://data.fung.es"
 REGIONS = {
     "NE": (f"{R2_ROOT}/EU/NE/NE_weather_data.parquet", (-25, 47, 45, 72)),
     "SE": (f"{R2_ROOT}/EU/SE/SE_weather_data.parquet", (-25, 34, 45, 47)),

--- a/scripts/qa_season_page.py
+++ b/scripts/qa_season_page.py
@@ -16,7 +16,7 @@ OUT = QA / "season-timing.html"
 truth = json.loads((ROOT / "docs/qa/season-truth-2026/gbif-season-truth.json").read_text())
 analysis = json.loads((QA / "season-analysis.json").read_text())
 
-R2 = "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev"
+R2 = "https://data.fung.es"
 CURVE_URLS = {"NE": f"{R2}/EU/NE/NE_season_curves.json", "SE": f"{R2}/EU/SE/SE_season_curves.json",
               "USE": f"{R2}/USA/USE/USE_season_curves.json", "USW": f"{R2}/USA/USW/USW_season_curves.json"}
 session = requests.Session()

--- a/src/lib/bioclip/variant.ts
+++ b/src/lib/bioclip/variant.ts
@@ -23,7 +23,7 @@ import { BioclipSession } from './session';
  * vocabulary both measure 1.06% false-edible@1 against fp32's 0.91%.
  */
 
-const R2 = 'https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev';
+const R2 = 'https://data.fung.es';
 
 export type ModelVariant = 'int4' | 'int8';
 

--- a/src/lib/offlineCache.ts
+++ b/src/lib/offlineCache.ts
@@ -5,7 +5,7 @@ export type ContinentId = 'eu' | 'us';
 
 export const CONTINENTS: ContinentId[] = ['eu', 'us'];
 
-const R2 = 'https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev';
+const R2 = 'https://data.fung.es';
 
 // Each continent's presence+forecast data lives in one PMTiles file per region
 // (NE+SE share the EU bbox, USE+USW share the US bbox — see mapStore's REGION_BBOX).

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,11 +19,6 @@ hydrateOfflineSources()
     console.warn('Offline cache hydration skipped:', err);
   });
 
-// Import Why Did You Render in development
-if (process.env.NODE_ENV === 'development') {
-  import('./lib/wdyr');
-}
-
 // Initialize HTML and manifest localization
 initializeHtmlLocalization();
 

--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -44,7 +44,7 @@ function dayLabel(d: number): string {
   return d === 365 ? '1y' : `${d}d`;
 }
 
-const R2 = 'https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev';
+const R2 = 'https://data.fung.es';
 
 const REGION_FILES: Record<RegionId, { label: string; url: string }[]> = {
   NE: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -176,7 +176,9 @@ export default defineConfig({
               /funges_style(_dark|_positron|_darkmatter|_topographic)?\.json$/i,
             handler: 'StaleWhileRevalidate',
             options: {
-              cacheName: 'map-style-cache',
+              // Bump when style source URLs change so a newly deployed service
+              // worker cannot serve JSON that still points at a retired host.
+              cacheName: 'map-style-cache-v2',
               expiration: {
                 maxEntries: 6,
                 maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days


### PR DESCRIPTION
## What changed

- replace production `pub-….r2.dev` data URLs with the R2 custom domain `https://data.fung.es`
- update map styles, downloads, offline caching, model artifacts, data scripts, and preconnects
- bump the Workbox map-style cache so existing clients do not retain styles pointing at the retired host
- remove the broken development-only Why Did You Render import that raised `require is not defined`

## Root cause and impact

The public R2 development endpoint was unreliable for production traffic, leaving the map stuck on its loading state. The custom domain uses the production Cloudflare path and supports the range requests required by PMTiles.

## Validation

- `npm run test -- --run --project unit`: 263 passed, 1 todo
- `npm run build`: passed; PWA generated with 121 precache entries
- production-preview browser smoke test: map rendered, loading screen cleared, all five PMTiles sources returned HTTP 206 from `data.fung.es`, no failed requests or console errors
- `git diff --check`: passed

The repository's general/targeted lint remains blocked by its existing Windows CRLF versus Prettier line-ending mismatch. The default all-project Vitest startup also remains blocked by the pre-existing Storybook `browser.provider` configuration; the configured unit project passes.