### PR TITLE
Remove remaining r2.dev references

### DIFF
--- a/docs/qa/gbif-effort-background-2026-06-01_2026-08-12-human/run-metadata.json
+++ b/docs/qa/gbif-effort-background-2026-06-01_2026-08-12-human/run-metadata.json
@@ -14,11 +14,11 @@
   "r2": {
     "NE": {
       "grid_points": 66936,
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_weather_data.parquet"
+      "source_url": "https://data.fung.es/EU/NE/NE_weather_data.parquet"
     },
     "SE": {
       "grid_points": 101447,
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_weather_data.parquet"
+      "source_url": "https://data.fung.es/EU/SE/SE_weather_data.parquet"
     }
   },
   "gbif_counts": {

--- a/docs/qa/gbif-scores-2026-08-13-season-aware/report.md
+++ b/docs/qa/gbif-scores-2026-08-13-season-aware/report.md
@@ -472,7 +472,7 @@ The fungal curves were themselves derived from 2020–2026 GBIF monthly ratios, 
       "min_points_per_day": 66936,
       "row_groups": 9,
       "rows": 8496542,
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_weather_data.parquet"
+      "source_url": "https://data.fung.es/EU/NE/NE_weather_data.parquet"
     },
     "SE": {
       "dates_seen": 61,
@@ -481,7 +481,7 @@ The fungal curves were themselves derived from 2020–2026 GBIF monthly ratios, 
       "min_points_per_day": 101447,
       "row_groups": 13,
       "rows": 12883769,
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_weather_data.parquet"
+      "source_url": "https://data.fung.es/EU/SE/SE_weather_data.parquet"
     },
     "USE": {
       "dates_seen": 61,
@@ -490,7 +490,7 @@ The fungal curves were themselves derived from 2020–2026 GBIF monthly ratios, 
       "min_points_per_day": 71157,
       "row_groups": 9,
       "rows": 8965782,
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_weather_data.parquet"
+      "source_url": "https://data.fung.es/USA/USE/USE_weather_data.parquet"
     },
     "USW": {
       "dates_seen": 61,
@@ -499,34 +499,34 @@ The fungal curves were themselves derived from 2020–2026 GBIF monthly ratios, 
       "min_points_per_day": 108586,
       "row_groups": 13,
       "rows": 13573250,
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_weather_data.parquet"
+      "source_url": "https://data.fung.es/USA/USW/USW_weather_data.parquet"
     }
   },
   "season_filter": {
     "fungi_curve_sources": {
       "NE": {
-        "region": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_season_curves.json",
-        "zone": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/EU_zone_season_curves.json"
+        "region": "https://data.fung.es/EU/NE/NE_season_curves.json",
+        "zone": "https://data.fung.es/EU/EU_zone_season_curves.json"
       },
       "SE": {
-        "region": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_season_curves.json",
-        "zone": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/EU_zone_season_curves.json"
+        "region": "https://data.fung.es/EU/SE/SE_season_curves.json",
+        "zone": "https://data.fung.es/EU/EU_zone_season_curves.json"
       },
       "USE": {
-        "region": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_season_curves.json",
-        "zone": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/US_zone_season_curves.json"
+        "region": "https://data.fung.es/USA/USE/USE_season_curves.json",
+        "zone": "https://data.fung.es/USA/US_zone_season_curves.json"
       },
       "USW": {
-        "region": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_season_curves.json",
-        "zone": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/US_zone_season_curves.json"
+        "region": "https://data.fung.es/USA/USW/USW_season_curves.json",
+        "zone": "https://data.fung.es/USA/US_zone_season_curves.json"
       }
     },
     "fungi_curve_threshold": 0.8,
     "plant_month_sources": {
-      "NE": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_species_params.txt",
-      "SE": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_species_params.txt",
-      "USE": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_species_params.txt",
-      "USW": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_species_params.txt"
+      "NE": "https://data.fung.es/EU/NE/NE_species_params.txt",
+      "SE": "https://data.fung.es/EU/SE/SE_species_params.txt",
+      "USE": "https://data.fung.es/USA/USE/USE_species_params.txt",
+      "USW": "https://data.fung.es/USA/USW/USW_species_params.txt"
     },
     "plant_season_months": {
       "NE": {

--- a/docs/qa/gbif-scores-2026-08-13-season-aware/run-metadata.json
+++ b/docs/qa/gbif-scores-2026-08-13-season-aware/run-metadata.json
@@ -387,7 +387,7 @@
   "gbif_deduplicated_records": 16376,
   "r2": {
     "NE": {
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_weather_data.parquet",
+      "source_url": "https://data.fung.es/EU/NE/NE_weather_data.parquet",
       "rows": 8496542,
       "row_groups": 9,
       "grid_points": 66936,
@@ -396,7 +396,7 @@
       "max_points_per_day": 66936
     },
     "SE": {
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_weather_data.parquet",
+      "source_url": "https://data.fung.es/EU/SE/SE_weather_data.parquet",
       "rows": 12883769,
       "row_groups": 13,
       "grid_points": 101447,
@@ -405,7 +405,7 @@
       "max_points_per_day": 101447
     },
     "USE": {
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_weather_data.parquet",
+      "source_url": "https://data.fung.es/USA/USE/USE_weather_data.parquet",
       "rows": 8965782,
       "row_groups": 9,
       "grid_points": 71157,
@@ -414,7 +414,7 @@
       "max_points_per_day": 71157
     },
     "USW": {
-      "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_weather_data.parquet",
+      "source_url": "https://data.fung.es/USA/USW/USW_weather_data.parquet",
       "rows": 13573250,
       "row_groups": 13,
       "grid_points": 108586,
@@ -591,27 +591,27 @@
     "fungi_curve_threshold": 0.8,
     "fungi_curve_sources": {
       "NE": {
-        "region": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_season_curves.json",
-        "zone": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/EU_zone_season_curves.json"
+        "region": "https://data.fung.es/EU/NE/NE_season_curves.json",
+        "zone": "https://data.fung.es/EU/EU_zone_season_curves.json"
       },
       "SE": {
-        "region": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_season_curves.json",
-        "zone": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/EU_zone_season_curves.json"
+        "region": "https://data.fung.es/EU/SE/SE_season_curves.json",
+        "zone": "https://data.fung.es/EU/EU_zone_season_curves.json"
       },
       "USE": {
-        "region": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_season_curves.json",
-        "zone": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/US_zone_season_curves.json"
+        "region": "https://data.fung.es/USA/USE/USE_season_curves.json",
+        "zone": "https://data.fung.es/USA/US_zone_season_curves.json"
       },
       "USW": {
-        "region": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_season_curves.json",
-        "zone": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/US_zone_season_curves.json"
+        "region": "https://data.fung.es/USA/USW/USW_season_curves.json",
+        "zone": "https://data.fung.es/USA/US_zone_season_curves.json"
       }
     },
     "plant_month_sources": {
-      "NE": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_species_params.txt",
-      "SE": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_species_params.txt",
-      "USE": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_species_params.txt",
-      "USW": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_species_params.txt"
+      "NE": "https://data.fung.es/EU/NE/NE_species_params.txt",
+      "SE": "https://data.fung.es/EU/SE/SE_species_params.txt",
+      "USE": "https://data.fung.es/USA/USE/USE_species_params.txt",
+      "USW": "https://data.fung.es/USA/USW/USW_species_params.txt"
     },
     "plant_season_months": {
       "NE": {

--- a/docs/qa/resilient-score-comparison-2026-06-01_2026-08-12/summary.json
+++ b/docs/qa/resilient-score-comparison-2026-06-01_2026-08-12/summary.json
@@ -17,13 +17,13 @@
   "primary_auc_delta": 0.005104772076720183,
   "regions": {
     "NE": {
-      "r2_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_weather_data.parquet",
+      "r2_url": "https://data.fung.es/EU/NE/NE_weather_data.parquet",
       "grid_points": 66936,
       "replayed_location_days": 44236,
       "history_rows": 1861888
     },
     "SE": {
-      "r2_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_weather_data.parquet",
+      "r2_url": "https://data.fung.es/EU/SE/SE_weather_data.parquet",
       "grid_points": 101447,
       "replayed_location_days": 11224,
       "history_rows": 703024

--- a/docs/qa/season-timing-2026/branch-replay-metadata.json
+++ b/docs/qa/season-timing-2026/branch-replay-metadata.json
@@ -10,7 +10,7 @@
       "2026-05-24",
       "2026-08-20"
     ],
-    "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_weather_data.parquet"
+    "source_url": "https://data.fung.es/EU/NE/NE_weather_data.parquet"
   },
   "SE": {
     "grid_points": 101447,
@@ -23,6 +23,6 @@
       "2026-05-24",
       "2026-08-20"
     ],
-    "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_weather_data.parquet"
+    "source_url": "https://data.fung.es/EU/SE/SE_weather_data.parquet"
   }
 }

--- a/docs/qa/season-timing-2026/scan-metadata.json
+++ b/docs/qa/season-timing-2026/scan-metadata.json
@@ -18,7 +18,7 @@
     ],
     "records_in_region": 3048,
     "records_matched": 1977,
-    "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/NE/NE_weather_data.parquet"
+    "source_url": "https://data.fung.es/EU/NE/NE_weather_data.parquet"
   },
   "SE": {
     "grid_points": 101447,
@@ -45,7 +45,7 @@
     ],
     "records_in_region": 468,
     "records_matched": 440,
-    "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/EU/SE/SE_weather_data.parquet"
+    "source_url": "https://data.fung.es/EU/SE/SE_weather_data.parquet"
   },
   "USE": {
     "grid_points": 71157,
@@ -66,7 +66,7 @@
     ],
     "records_in_region": 2005,
     "records_matched": 1650,
-    "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USE/USE_weather_data.parquet"
+    "source_url": "https://data.fung.es/USA/USE/USE_weather_data.parquet"
   },
   "USW": {
     "grid_points": 108586,
@@ -91,6 +91,6 @@
     ],
     "records_in_region": 1022,
     "records_matched": 935,
-    "source_url": "https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev/USA/USW/USW_weather_data.parquet"
+    "source_url": "https://data.fung.es/USA/USW/USW_weather_data.parquet"
   }
 }

--- a/docs/superpowers/plans/2026-06-25-forecast-slider.md
+++ b/docs/superpowers/plans/2026-06-25-forecast-slider.md
@@ -439,7 +439,7 @@ Create `scripts/add-forecast-layers.cjs`:
 // Usage: node scripts/add-forecast-layers.cjs [public/funges_style.json ...]
 const fs = require('fs');
 
-const R2 = 'https://pub-9988c4492e7945f0a2ff14e35232acdf.r2.dev';
+const R2 = 'https://data.fung.es';
 // overlay source id -> [forecast source id, forecast pmtiles url, forecast source-layer]
 const FC = {
   'overlay-ne':  ['forecast-ne',  `${R2}/EU/NE/ne_forecast.pmtiles`,   'ne_forecast'],


### PR DESCRIPTION
## What changed

- replace the remaining `pub-….r2.dev` URLs in QA metadata, reports, and the archived forecast implementation plan with `https://data.fung.es`
- leave application code and the WDYR development utility untouched

## Why

Production data now uses the R2 custom domain. Removing the obsolete hostname from repository documentation prevents stale URLs from being copied into future scripts or mistaken for active dependencies.

## Validation

- repository-wide search: zero remaining `r2.dev` references
- all five edited JSON documents parse successfully
- `git diff --check`: passed

This is documentation and metadata only, so no runtime bundle is changed.