### PR TITLE
Fix offline availability message

### DIFF
--- a/src/i18n/locales/de/map.json
+++ b/src/i18n/locales/de/map.json
@@ -114,6 +114,6 @@
   },
   "offline": {
     "title": "Keine Verbindung",
-    "message": "Die Karte braucht eine Internetverbindung. Arten, Rezepte und die Datenseiten funktionieren weiterhin offline."
+    "message": "Die Karte braucht eine Internetverbindung. Arten und Rezepte funktionieren weiterhin offline."
   }
 }

--- a/src/i18n/locales/en/map.json
+++ b/src/i18n/locales/en/map.json
@@ -114,6 +114,6 @@
   },
   "offline": {
     "title": "You're offline",
-    "message": "The map needs a connection to load. Species, recipes and the data pages still work offline."
+    "message": "The map needs a connection to load. Species and recipes still work offline."
   }
 }

--- a/src/i18n/locales/es/map.json
+++ b/src/i18n/locales/es/map.json
@@ -114,6 +114,6 @@
   },
   "offline": {
     "title": "Sin conexión",
-    "message": "El mapa necesita conexión para cargarse. Las especies, las recetas y las páginas de datos siguen funcionando sin conexión."
+    "message": "El mapa necesita conexión para cargarse. Las especies y las recetas siguen funcionando sin conexión."
   }
 }

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -114,6 +114,6 @@
   },
   "offline": {
     "title": "Hors connexion",
-    "message": "La carte a besoin d'une connexion pour se charger. Les espèces, les recettes et les pages de données fonctionnent hors connexion."
+    "message": "La carte a besoin d'une connexion pour se charger. Les espèces et les recettes fonctionnent hors connexion."
   }
 }

--- a/src/i18n/locales/it/map.json
+++ b/src/i18n/locales/it/map.json
@@ -114,6 +114,6 @@
   },
   "offline": {
     "title": "Nessuna connessione",
-    "message": "La mappa ha bisogno di una connessione per caricarsi. Specie, ricette e le pagine dati funzionano anche offline."
+    "message": "La mappa ha bisogno di una connessione per caricarsi. Specie e ricette funzionano anche offline."
   }
 }

--- a/src/i18n/locales/pt/map.json
+++ b/src/i18n/locales/pt/map.json
@@ -114,6 +114,6 @@
   },
   "offline": {
     "title": "Sem conexão",
-    "message": "O mapa precisa de conexão para carregar. Espécies, receitas e as páginas de dados continuam funcionando offline."
+    "message": "O mapa precisa de conexão para carregar. Espécies e receitas continuam funcionando offline."
   }
 }


### PR DESCRIPTION
## What changed

Removed the incorrect claim that the data page remains available offline from the map's offline message in all six supported locales.

## Why

The data page does not work offline, so the existing message gave users inaccurate availability guidance.

## Impact

The offline notice now states only that species and recipes remain available offline.

## Validation

- Changed locale JSON files parse successfully
- Targeted Prettier check passes
- `git diff --check` passes
- Full lint is currently blocked by existing repository-wide CRLF/Prettier failures
- Vitest is currently blocked during startup by the existing browser provider configuration