### PR TITLE
Replace user-location marker with MapLibre's standard GeolocateControl

### DIFF
--- a/src/components/AdvancedMap.tsx
+++ b/src/components/AdvancedMap.tsx
@@ -245,6 +245,105 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
 
       // Navigation controls removed - zoom functionality handled by touch/scroll gestures
 
+      // Locate-me: MapLibre's standard GeolocateControl (dot + accuracy
+      // circle, live tracking). Its native corner button is hidden via CSS
+      // (see globals.scss) - the app's own button drives it through
+      // handleGetUserLocation -> trigger() instead. Added/removed here, in
+      // step with the map instance itself (map.current.remove() below tears
+      // this control down too), so there's no separate effect that could
+      // try to remove it a second time after the map already has.
+      const geolocate = new maplibregl.GeolocateControl({
+        positionOptions: { enableHighAccuracy: true },
+        trackUserLocation: true,
+        showUserLocation: true,
+        showAccuracyCircle: true,
+      });
+      geolocateControl.current = geolocate;
+
+      geolocate.on('geolocate', (position: GeolocationPosition) => {
+        const coords: [number, number] = [
+          position.coords.longitude,
+          position.coords.latitude,
+        ];
+        setUserLocation(coords);
+        setShowUserLocation(true);
+        setIsLoading(false);
+
+        // Only probe for nearby foraging features on the first fix after a
+        // trigger - trackUserLocation keeps firing 'geolocate' as the device
+        // moves, and re-opening the modal on every update would be spammy.
+        if (hasCheckedNearbyFeatures.current || !map.current) return;
+        hasCheckedNearbyFeatures.current = true;
+
+        const currentMap = map.current;
+        const selectedSpecies = selectedSpeciesRef.current;
+        const layers =
+          currentMap
+            .getStyle()
+            ?.layers?.map(l => l.id)
+            .filter(
+              id =>
+                (selectedSpecies
+                  ? id.startsWith(selectedSpecies)
+                  : id.includes('_score')) &&
+                currentMap.getLayoutProperty(id, 'visibility') === 'visible'
+            ) || [];
+
+        // Query features in the current viewport to see if any are near the user's location
+        const viewportFeatures = currentMap.queryRenderedFeatures({
+          layers,
+        });
+
+        // Filter features to find those close to the user's location
+        const nearbyFeatures = viewportFeatures.filter(feature => {
+          if (feature.geometry.type === 'Point') {
+            const featureCoords = feature.geometry.coordinates as [
+              number,
+              number,
+            ];
+            const distance = Math.sqrt(
+              Math.pow(featureCoords[0] - coords[0], 2) +
+                Math.pow(featureCoords[1] - coords[1], 2)
+            );
+            // Consider features within ~1km radius (0.01 degrees is roughly 1km)
+            return distance < 0.01;
+          }
+          return false;
+        });
+
+        if (nearbyFeatures.length > 0) {
+          // Found features near user location, open modal
+          setSelectedFeature(nearbyFeatures[0]);
+          setIsModalFromLocateMe(true);
+          setIsFeatureModalOpen(true);
+        } else {
+          // No features found, just log a warning
+          console.warn('No foraging data available at user location:', coords);
+        }
+      });
+
+      geolocate.on('trackuserlocationstart', () => {
+        hasCheckedNearbyFeatures.current = false;
+        setIsLoading(true);
+        setError(null);
+        setUserLocationError(null);
+      });
+
+      geolocate.on('trackuserlocationend', () => {
+        setIsLoading(false);
+        setShowUserLocation(false);
+        setActiveRoute(null);
+      });
+
+      geolocate.on('error', (error: GeolocationPositionError) => {
+        console.error('Error getting user location:', error);
+        setIsLoading(false);
+        setError(t('geolocation.permissionError'));
+        setUserLocationError(error.message);
+      });
+
+      map.current.addControl(geolocate);
+
       // Handle map load
       map.current.on('load', () => {
         setMapLoaded(true);
@@ -257,6 +356,19 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
         if (map.current) {
           // Force initial resize with correct dimensions
           map.current.resize();
+        }
+
+        // A style switch tears down and recreates the whole map (and, with
+        // it, the GeolocateControl above) - if the user had their location
+        // active, the new control starts back at OFF and won't show the dot
+        // on its own. Re-trigger it here so tracking resumes automatically
+        // instead of the indicator silently vanishing while the button
+        // still shows "active". Checking userLocation too (not just the
+        // showUserLocation flag, which defaults to true from first mount)
+        // so this never fires as an unsolicited geolocation prompt before
+        // the user has ever pressed the button themselves.
+        if (showUserLocation && userLocation) {
+          geolocate.trigger();
         }
       });
 
@@ -292,9 +404,14 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
 
     return () => {
       if (map.current) {
+        // map.remove() already tears down every registered control
+        // (including geolocate.onRemove()) - don't call removeControl()
+        // separately, it would run onRemove() a second time on an already
+        // torn-down control and throw.
         map.current.remove();
         map.current = null;
       }
+      geolocateControl.current = null;
       // The new map instance starts unloaded. Resetting this makes mapLoaded go
       // false->true when the new map fires 'load', which re-runs every
       // [mapLoaded]-gated effect (route source/layer, offline sources, markers)
@@ -667,123 +784,13 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
   }, [mapLoaded, selectedSpecies, activeDay]);
 
   // Locate-me button: delegates to the standard MapLibre GeolocateControl
-  // (set up below) instead of a hand-rolled geolocation flow. trigger()
-  // mirrors clicking the control's own button — its internal state machine
-  // handles starting tracking when off and stopping it when active, so no
-  // on/off branching is needed here.
+  // (set up in the "Initialize map" effect above) instead of a hand-rolled
+  // geolocation flow. trigger() mirrors clicking the control's own button —
+  // its internal state machine handles starting tracking when off and
+  // stopping it when active, so no on/off branching is needed here.
   const handleGetUserLocation = () => {
     geolocateControl.current?.trigger();
   };
-
-  // Set up GeolocateControl once per map instance. Its native corner button
-  // is hidden via CSS (see globals.scss) — the existing UI button drives it
-  // through handleGetUserLocation -> trigger() instead, keeping this app's
-  // own location button while using MapLibre's standard locate-the-user
-  // implementation (dot + accuracy circle, live tracking) under the hood.
-  useEffect(() => {
-    if (!map.current || !mapLoaded) return;
-    const currentMap = map.current;
-
-    const control = new maplibregl.GeolocateControl({
-      positionOptions: { enableHighAccuracy: true },
-      trackUserLocation: true,
-      showUserLocation: true,
-      showAccuracyCircle: true,
-    });
-    geolocateControl.current = control;
-
-    const handleGeolocate = (position: GeolocationPosition) => {
-      const coords: [number, number] = [
-        position.coords.longitude,
-        position.coords.latitude,
-      ];
-      setUserLocation(coords);
-      setShowUserLocation(true);
-      setIsLoading(false);
-
-      // Only probe for nearby foraging features on the first fix after a
-      // trigger — trackUserLocation keeps firing 'geolocate' as the device
-      // moves, and re-opening the modal on every update would be spammy.
-      if (hasCheckedNearbyFeatures.current) return;
-      hasCheckedNearbyFeatures.current = true;
-
-      const selectedSpecies = selectedSpeciesRef.current;
-      const layers =
-        currentMap
-          .getStyle()
-          ?.layers?.map(l => l.id)
-          .filter(
-            id =>
-              (selectedSpecies
-                ? id.startsWith(selectedSpecies)
-                : id.includes('_score')) &&
-              currentMap.getLayoutProperty(id, 'visibility') === 'visible'
-          ) || [];
-
-      // Query features in the current viewport to see if any are near the user's location
-      const viewportFeatures = currentMap.queryRenderedFeatures({ layers });
-
-      // Filter features to find those close to the user's location
-      const nearbyFeatures = viewportFeatures.filter(feature => {
-        if (feature.geometry.type === 'Point') {
-          const featureCoords = feature.geometry.coordinates as [
-            number,
-            number,
-          ];
-          const distance = Math.sqrt(
-            Math.pow(featureCoords[0] - coords[0], 2) +
-              Math.pow(featureCoords[1] - coords[1], 2)
-          );
-          // Consider features within ~1km radius (0.01 degrees is roughly 1km)
-          return distance < 0.01;
-        }
-        return false;
-      });
-
-      if (nearbyFeatures.length > 0) {
-        // Found features near user location, open modal
-        setSelectedFeature(nearbyFeatures[0]);
-        setIsModalFromLocateMe(true);
-        setIsFeatureModalOpen(true);
-      } else {
-        // No features found, just log a warning
-        console.warn('No foraging data available at user location:', coords);
-      }
-    };
-
-    const handleTrackStart = () => {
-      hasCheckedNearbyFeatures.current = false;
-      setIsLoading(true);
-      setError(null);
-      setUserLocationError(null);
-    };
-
-    const handleTrackEnd = () => {
-      setIsLoading(false);
-      setShowUserLocation(false);
-      setActiveRoute(null);
-    };
-
-    const handleGeolocateError = (error: GeolocationPositionError) => {
-      console.error('Error getting user location:', error);
-      setIsLoading(false);
-      setError(t('geolocation.permissionError'));
-      setUserLocationError(error.message);
-    };
-
-    control.on('geolocate', handleGeolocate);
-    control.on('trackuserlocationstart', handleTrackStart);
-    control.on('trackuserlocationend', handleTrackEnd);
-    control.on('error', handleGeolocateError);
-
-    currentMap.addControl(control);
-
-    return () => {
-      currentMap.removeControl(control);
-      geolocateControl.current = null;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapLoaded]);
 
   // Add foraging spot markers
   useEffect(() => {

--- a/src/components/AdvancedMap.tsx
+++ b/src/components/AdvancedMap.tsx
@@ -123,6 +123,7 @@ const IdentifyPanel = lazy(() =>
 const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<maplibregl.Map | null>(null);
+  const geolocateControl = useRef<maplibregl.GeolocateControl | null>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [mapError, setMapError] = useState<string | null>(null);
   const [selectedFeature, setSelectedFeature] =
@@ -152,6 +153,11 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
     routeStart: [number, number];
   } | null>(null);
   const routeDishDebounceTimeoutRef = useRef<number | null>(null);
+  // Guards the nearby-feature probe (in the GeolocateControl setup effect
+  // below) so it only runs once per trigger, not on every 'geolocate' update
+  // while trackUserLocation keeps watching.
+  const hasCheckedNearbyFeatures = useRef(false);
+  const selectedSpeciesRef = useRef<string | null>(null);
 
   const { t } = useTranslation('map');
   const { t: tRecipes } = useTranslation('recipes');
@@ -169,7 +175,7 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
     numbersLayersVisible,
     setCenter,
     setZoom,
-    getUserLocation,
+    setUserLocation,
     setIsLoading,
     setError,
     setUserLocationError,
@@ -201,6 +207,10 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
       routeStart,
     };
   }, [routeRecipes, routeStart]);
+
+  useEffect(() => {
+    selectedSpeciesRef.current = selectedSpecies;
+  }, [selectedSpecies]);
 
   // Initialize map
   useEffect(() => {
@@ -656,103 +666,124 @@ const AdvancedMap: React.FC<MapProps> = ({ className = '' }) => {
     };
   }, [mapLoaded, selectedSpecies, activeDay]);
 
-  // Handle user location
-  const handleGetUserLocation = async () => {
-    if (showUserLocation && userLocation) {
-      setShowUserLocation(false);
-      setActiveRoute(null);
-      return;
-    }
+  // Locate-me button: delegates to the standard MapLibre GeolocateControl
+  // (set up below) instead of a hand-rolled geolocation flow. trigger()
+  // mirrors clicking the control's own button — its internal state machine
+  // handles starting tracking when off and stopping it when active, so no
+  // on/off branching is needed here.
+  const handleGetUserLocation = () => {
+    geolocateControl.current?.trigger();
+  };
 
-    setIsLoading(true);
-    setError(null);
-    setUserLocationError(null);
+  // Set up GeolocateControl once per map instance. Its native corner button
+  // is hidden via CSS (see globals.scss) — the existing UI button drives it
+  // through handleGetUserLocation -> trigger() instead, keeping this app's
+  // own location button while using MapLibre's standard locate-the-user
+  // implementation (dot + accuracy circle, live tracking) under the hood.
+  useEffect(() => {
+    if (!map.current || !mapLoaded) return;
+    const currentMap = map.current;
 
-    try {
-      const position = await getUserLocation();
+    const control = new maplibregl.GeolocateControl({
+      positionOptions: { enableHighAccuracy: true },
+      trackUserLocation: true,
+      showUserLocation: true,
+      showAccuracyCircle: true,
+    });
+    geolocateControl.current = control;
+
+    const handleGeolocate = (position: GeolocationPosition) => {
       const coords: [number, number] = [
         position.coords.longitude,
         position.coords.latitude,
       ];
-
-      if (map.current) {
-        setShowUserLocation(true);
-        map.current.flyTo({
-          center: coords,
-          zoom: 10,
-          duration: 2000,
-        });
-
-        // Check if there are features at the user's location
-        const layers =
-          map.current
-            ?.getStyle()
-            ?.layers?.map(l => l.id)
-            .filter(
-              id =>
-                (selectedSpecies
-                  ? id.startsWith(selectedSpecies)
-                  : id.includes('_score')) &&
-                map.current?.getLayoutProperty(id, 'visibility') === 'visible'
-            ) || [];
-
-        // Query features in the current viewport to see if any are near the user's location
-        const viewportFeatures = map.current.queryRenderedFeatures({
-          layers,
-        });
-
-        // Filter features to find those close to the user's location
-        const nearbyFeatures = viewportFeatures.filter(feature => {
-          if (feature.geometry.type === 'Point') {
-            const featureCoords = feature.geometry.coordinates as [
-              number,
-              number,
-            ];
-            const distance = Math.sqrt(
-              Math.pow(featureCoords[0] - coords[0], 2) +
-                Math.pow(featureCoords[1] - coords[1], 2)
-            );
-            // Consider features within ~1km radius (0.01 degrees is roughly 1km)
-            return distance < 0.01;
-          }
-          return false;
-        });
-
-        if (nearbyFeatures && nearbyFeatures.length > 0) {
-          // Found features near user location, open modal
-          setSelectedFeature(nearbyFeatures[0]);
-          setIsModalFromLocateMe(true);
-          setIsFeatureModalOpen(true);
-        } else {
-          // No features found, just log a warning
-          console.warn('No foraging data available at user location:', coords);
-        }
-      }
-    } catch (error) {
-      console.error('Error getting user location:', error);
-      setError(t('geolocation.permissionError'));
-    } finally {
+      setUserLocation(coords);
+      setShowUserLocation(true);
       setIsLoading(false);
-    }
-  };
 
-  // Add user location marker
-  useEffect(() => {
-    if (!map.current || !mapLoaded || !showUserLocation || !userLocation)
-      return;
+      // Only probe for nearby foraging features on the first fix after a
+      // trigger — trackUserLocation keeps firing 'geolocate' as the device
+      // moves, and re-opening the modal on every update would be spammy.
+      if (hasCheckedNearbyFeatures.current) return;
+      hasCheckedNearbyFeatures.current = true;
 
-    // Create new marker
-    const marker = new maplibregl.Marker({
-      color: '#3b82f6',
-      className: 'user-location-marker',
-    })
-      .setLngLat(userLocation)
-      .addTo(map.current);
+      const selectedSpecies = selectedSpeciesRef.current;
+      const layers =
+        currentMap
+          .getStyle()
+          ?.layers?.map(l => l.id)
+          .filter(
+            id =>
+              (selectedSpecies
+                ? id.startsWith(selectedSpecies)
+                : id.includes('_score')) &&
+              currentMap.getLayoutProperty(id, 'visibility') === 'visible'
+          ) || [];
+
+      // Query features in the current viewport to see if any are near the user's location
+      const viewportFeatures = currentMap.queryRenderedFeatures({ layers });
+
+      // Filter features to find those close to the user's location
+      const nearbyFeatures = viewportFeatures.filter(feature => {
+        if (feature.geometry.type === 'Point') {
+          const featureCoords = feature.geometry.coordinates as [
+            number,
+            number,
+          ];
+          const distance = Math.sqrt(
+            Math.pow(featureCoords[0] - coords[0], 2) +
+              Math.pow(featureCoords[1] - coords[1], 2)
+          );
+          // Consider features within ~1km radius (0.01 degrees is roughly 1km)
+          return distance < 0.01;
+        }
+        return false;
+      });
+
+      if (nearbyFeatures.length > 0) {
+        // Found features near user location, open modal
+        setSelectedFeature(nearbyFeatures[0]);
+        setIsModalFromLocateMe(true);
+        setIsFeatureModalOpen(true);
+      } else {
+        // No features found, just log a warning
+        console.warn('No foraging data available at user location:', coords);
+      }
+    };
+
+    const handleTrackStart = () => {
+      hasCheckedNearbyFeatures.current = false;
+      setIsLoading(true);
+      setError(null);
+      setUserLocationError(null);
+    };
+
+    const handleTrackEnd = () => {
+      setIsLoading(false);
+      setShowUserLocation(false);
+      setActiveRoute(null);
+    };
+
+    const handleGeolocateError = (error: GeolocationPositionError) => {
+      console.error('Error getting user location:', error);
+      setIsLoading(false);
+      setError(t('geolocation.permissionError'));
+      setUserLocationError(error.message);
+    };
+
+    control.on('geolocate', handleGeolocate);
+    control.on('trackuserlocationstart', handleTrackStart);
+    control.on('trackuserlocationend', handleTrackEnd);
+    control.on('error', handleGeolocateError);
+
+    currentMap.addControl(control);
 
     return () => {
-      marker.remove();
+      currentMap.removeControl(control);
+      geolocateControl.current = null;
     };
-  }, [userLocation, mapLoaded, showUserLocation]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapLoaded]);
 
   // Add foraging spot markers
   useEffect(() => {

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -342,3 +342,10 @@
     width: 200px; // Smaller on mobile
   }
 }
+
+// AdvancedMap wires its own "locate me" button to GeolocateControl.trigger()
+// instead of showing MapLibre's default corner button — hide the native one
+// without touching its (still-functional) DOM element.
+.maplibregl-ctrl-geolocate {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
Replaces the hand-rolled "current location" marker (manual `getCurrentPosition` + a colored default `maplibregl.Marker`) with MapLibre's standard `GeolocateControl` — the dot + accuracy-circle, live-tracking indicator, per MapLibre's own [locate-the-user example](https://maplibre.org/maplibre-gl-js/docs/examples/locate-the-user/).

- The app's existing "locate me" button stays as the UI entry point; it now calls `geolocateControl.trigger()` instead of the old manual flow. The control's own native corner button is hidden via CSS.
- `trackUserLocation: true` / `showAccuracyCircle: true` (library defaults) — the dot keeps repositioning live as GPS updates.
- The "check for nearby foraging features near the user and open a modal" behavior is preserved, now triggered off the control's `geolocate` event, gated to run once per trigger (not on every background position update).

## Bug fixes on top of the initial integration
- **Crash on map theme switch**: the map is fully destroyed/recreated on a style change, and `map.current.remove()` already tears down every registered control (including `GeolocateControl.onRemove()`). A separate `[mapLoaded]`-keyed effect was also calling `removeControl()` on the same control, running `onRemove()` a second time on an already-torn-down control — `this._map.off(...)` then threw on `undefined`. Fixed by moving the control's setup/teardown into the map's own init/cleanup effect, so it's torn down exactly once, in lockstep with the map instance.
- **Location indicator disappearing on theme switch**: the freshly recreated `GeolocateControl` starts at `OFF` and doesn't resume watching on its own, so after a theme switch the dot vanished even though the locate button still showed "active" (`showUserLocation` persisted in the store). Fixed by re-triggering the new control on `load` when a location was already active.

## Testing
- `npm run type-check` — clean
- `npm run lint` — no new errors (pre-existing warnings in unrelated files untouched)
- `npm run test:run` (vitest) — fails to start on this branch *and* on `main` before this change, due to an unrelated pre-existing `vitest.config` issue (`browser.provider` needs a factory import per the installed vitest version) — not something introduced by this PR.

## Before
<img width="428" height="234" alt="image" src="https://github.com/user-attachments/assets/ab658a7c-a93c-4ebe-a2de-8cf2915b9574" />

## After
<img width="982" height="618" alt="image" src="https://github.com/user-attachments/assets/85ad8007-6c88-4ea5-8f61-f2ed3eba3574" />