### PR TITLE
Elevation/glass tokens, and one shared nav surface for Sidebar + MobileNavbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,10 @@ playwright-report/
 
 # Generated QA page (rebuild with scripts/qa_season_page.py)
 docs/qa/**/season-timing.html
+
+# ~/.gitignore (global excludesFile) blanket-ignores CONTEXT.md and docs/*
+# for other projects' scratch/Claude-generated files. This repo tracks both
+# for real (domain glossary, docs/qa, docs/superpowers, docs/adr, ...) —
+# un-ignore them here; the specific-file excludes above still apply.
+!CONTEXT.md
+!docs/*

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,7 +14,7 @@ _Avoid_: shadow depth, shadow tier, z-index level
 The elevation level for the map canvas itself — no shadow, no glass. Not a "surface" in this system's sense.
 
 **Raised**:
-The elevation level for small, static, fixed-size chrome that sits above the base surface without floating free of it (e.g. a card, the app sidebar).
+The elevation level for small, static, fixed-size chrome that sits above the base surface without floating free of it (e.g. a card, the app sidebar, the mobile bottom nav bar — persistent primary nav, not dismissed by tap-outside, so it doesn't qualify as Floating despite visually sitting over the map).
 
 **Raised-subtle**:
 A quieter variant of Raised for lightweight input chrome (e.g. a search field, a select trigger) — chrome you look through rather than press; no hover escalation.
@@ -34,3 +34,16 @@ The glass variant for chrome sitting over text content or the map (e.g. an info 
 
 **Glass-clear**:
 The more-transparent glass variant, reserved for full-bleed media backgrounds; never used over text content.
+
+**Note — `variant='floating'` naming collision**: shadcn's `Sidebar` component takes a `variant='floating'` prop — a layout/shape API (rounded corners, inset from the viewport edge). It is unrelated to this glossary's elevation-level **Floating** term above. `AppSidebar` uses shadcn's `variant='floating'` prop but its elevation level is **Raised**.
+
+### Design system — navigation & chrome
+
+Settled while deciding the nav/chrome paradigm for `src/components/Sidebar/` and `src/components/Mobile/MobileNavbar.tsx` (`lodist/funges#196`).
+
+**Relevance-based disclosure**:
+Showing or hiding nav items based on platform/feature context (e.g. mobile vs. desktop, an offline-features flag) rather than always rendering the full item set. Names an existing pattern already in `AppSidebar`/`MobileNavbar`, not a new mechanism introduced by #196.
+
+**Section-adaptive accent**:
+The active nav item's own tint (icon/label color, and scale on mobile) reflecting the current section — scoped to the active-item indicator only.
+_Avoid_: ambient/background retinting of the whole nav per section — considered and rejected (risks inconsistency and WCAG contrast issues); out of scope for #196.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,36 @@
+# funges
+
+A React/Vite/Tailwind foraging map PWA. This glossary currently covers the design-system vocabulary settled while inventorying `src/components/ui/*` for elevation/glass adoption (`lodist/funges#201`); other domain areas (species, routes, forecasting) can grow here under their own subheadings as they get grilled.
+
+## Language
+
+### Design system — elevation & glass
+
+**Elevation level**:
+One of four semantic surface roles — `base`, `raised`, `floating`, `overlay` — that determines how a component's shadow and depth cues read, chosen by role rather than by picking a raw shadow value.
+_Avoid_: shadow depth, shadow tier, z-index level
+
+**Base**:
+The elevation level for the map canvas itself — no shadow, no glass. Not a "surface" in this system's sense.
+
+**Raised**:
+The elevation level for small, static, fixed-size chrome that sits above the base surface without floating free of it (e.g. a card, the app sidebar).
+
+**Raised-subtle**:
+A quieter variant of Raised for lightweight input chrome (e.g. a search field, a select trigger) — chrome you look through rather than press; no hover escalation.
+
+**Floating**:
+The elevation level for dismiss-by-tap-outside surfaces that appear above other content and can be dismissed independently of it (e.g. a menu, a sheet, a tooltip).
+
+**Overlay**:
+The elevation level for blocking surfaces with a scrim that must be explicitly dismissed (e.g. a modal dialog).
+
+**Glass**:
+An opt-in translucent, blurred treatment layered on top of an elevation level — never a replacement for one. Restricted to `raised`/`floating` chrome that is small, fixed-size, and not text-heavy; never applied to `base` or `overlay`.
+_Avoid_: backdrop blur, frosted, liquid glass (the last is the Apple design language this is _inspired by_, not implementing)
+
+**Glass-regular**:
+The glass variant for chrome sitting over text content or the map (e.g. an info card floating over the map).
+
+**Glass-clear**:
+The more-transparent glass variant, reserved for full-bleed media backgrounds; never used over text content.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,3 +47,8 @@ Showing or hiding nav items based on platform/feature context (e.g. mobile vs. d
 **Section-adaptive accent**:
 The active nav item's own tint (icon/label color, and scale on mobile) reflecting the current section — scoped to the active-item indicator only.
 _Avoid_: ambient/background retinting of the whole nav per section — considered and rejected (risks inconsistency and WCAG contrast issues); out of scope for #196.
+_Note_: on `MobileNavbar` the tint needs a dark-mode step (`--happy-500` rather than `--happy-700`). The `--happy-*` scale is light-mode only, and `--happy-700` over the translucent dark surface falls to 1.7:1 against a light map — under WCAG 1.4.11's 3:1 floor. `AppSidebar` needs no equivalent: its accent rides on `--sidebar-accent-foreground`, which is already redefined per theme.
+
+**Shared nav surface**:
+Both nav surfaces are elevation level **Raised** with **Glass-regular**. The class names live in one place — `NAV_SURFACE_CLASS` in `src/lib/nav-surface.ts` — which `AppSidebar` (via `Sidebar`'s `surfaceClassOverride` prop) and `MobileNavbar` both consume, so the two platforms' chrome can't drift apart. `src/test/nav-surface.test.ts` guards the constant against naming a utility `globals.scss` no longer defines.
+_Note_: on `Sidebar` the treatment has to land on the painted surface (`data-slot='sidebar-inner'`), not the positioning container that `className` targets — the surface's own background otherwise paints over it. That was the bug in the hand-rolled `bg-background/95 backdrop-blur` this replaced.

--- a/docs/adr/0001-reconcile-trailhead-elevation-tokens.md
+++ b/docs/adr/0001-reconcile-trailhead-elevation-tokens.md
@@ -1,0 +1,12 @@
+# Reconcile Trailhead's shipped shadows onto the elevation/glass tokens
+
+`#213` ("Trailhead") shipped hardcoded, light-mode-only shadow values across several `src/components/ui/*` primitives (Card, Button, Input, Select, Dialog, DropdownMenu, Sheet) before `#195`/`#200`'s semantic elevation/glass token system (`raised`/`floating`/`overlay`, aliasing `#199`'s `--shadow-*` scale) had been implemented in code. Rather than ship the two systems in parallel or revert Trailhead's already-live look, `#201`'s component inventory canonicalizes Trailhead's shipped rgba values as the elevation tokens' source of truth: `raised` and `raised-subtle` (a quieter sub-token for input-style chrome — Card/Button's punchier hover-escalating shadow would visibly regress Input/Select Trigger's whisper-quiet pill shadow if collapsed onto one value, and vice versa) both trace to Trailhead's values, `floating` and `overlay` were already consistent across their components and needed no split. `glass` eligibility is restricted per-component (Card, Sidebar, Button's icon/map-control compound variant, Input, Select Trigger) rather than blanket-enabled on every `raised`/`floating` primitive, since several floating primitives are text-heavy menus/dialogs where glass would risk WCAG 1.4.11 contrast failures.
+
+## Considered Options
+
+- **Revert Trailhead's hardcoded shadows and implement `#200`'s tokens against the original `--shadow-*` scale as written.** Rejected: would visibly regress components already shipped to users for the sake of matching a spec that predates Trailhead; the token system's job is to formalize what's live, not to override it.
+- **One shared `raised` token instead of `raised`/`raised-subtle`.** Rejected: Trailhead shipped genuinely different shadow weights for "chrome you press" (Card, Button) vs. "chrome you look through" (Input, Select Trigger) — forcing one value regresses whichever side loses.
+
+## Consequences
+
+Dark-mode elevation — previously broken (dark shadow values were byte-identical to light) — gets fixed as a side effect, via `#200`'s `--glass-highlight` inset border applied to these same canonicalized levels, rather than as a separate follow-up.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --fix --max-warnings 0",
+      "eslint --fix --max-warnings 0 --no-warn-ignored",
       "prettier --write"
     ],
     "*.{json,css,scss,md,html}": [

--- a/src/components/FilterModal.tsx
+++ b/src/components/FilterModal.tsx
@@ -90,7 +90,7 @@ export default function FilterModal({
                 variant={selectedCategory === 'all' ? 'default' : 'outline'}
                 size='sm'
                 onClick={() => onCategoryChange('all')}
-                className={`transition-all duration-200 ${
+                className={`transition-all duration-[var(--duration-base)] ${
                   selectedCategory === 'all'
                     ? 'shadow-md scale-105'
                     : 'hover:scale-105'
@@ -109,7 +109,7 @@ export default function FilterModal({
                   }
                   size='sm'
                   onClick={() => onCategoryChange(category)}
-                  className={`transition-all duration-200 ${
+                  className={`transition-all duration-[var(--duration-base)] ${
                     selectedCategory === category
                       ? 'shadow-md scale-105'
                       : 'hover:scale-105'
@@ -138,7 +138,7 @@ export default function FilterModal({
                 variant={selectedDifficulty === 'all' ? 'default' : 'outline'}
                 size='sm'
                 onClick={() => onDifficultyChange('all')}
-                className={`transition-all duration-200 ${
+                className={`transition-all duration-[var(--duration-base)] ${
                   selectedDifficulty === 'all'
                     ? 'shadow-md scale-105'
                     : 'hover:scale-105'
@@ -157,7 +157,7 @@ export default function FilterModal({
                   }
                   size='sm'
                   onClick={() => onDifficultyChange(difficulty)}
-                  className={`transition-all duration-200 ${
+                  className={`transition-all duration-[var(--duration-base)] ${
                     selectedDifficulty === difficulty
                       ? 'shadow-md scale-105'
                       : 'hover:scale-105'
@@ -188,7 +188,7 @@ export default function FilterModal({
                 variant={selectedTag === 'all' ? 'default' : 'outline'}
                 size='sm'
                 onClick={() => onTagChange('all')}
-                className={`transition-all duration-200 ${
+                className={`transition-all duration-[var(--duration-base)] ${
                   selectedTag === 'all'
                     ? 'shadow-md scale-105'
                     : 'hover:scale-105'
@@ -207,7 +207,7 @@ export default function FilterModal({
                     variant={selectedTag === tag ? 'default' : 'outline'}
                     size='sm'
                     onClick={() => onTagChange(tag)}
-                    className={`transition-all duration-200 ${
+                    className={`transition-all duration-[var(--duration-base)] ${
                       selectedTag === tag
                         ? 'shadow-md scale-105'
                         : 'hover:scale-105'
@@ -229,7 +229,7 @@ export default function FilterModal({
           <Button
             variant='outline'
             onClick={onClearFilters}
-            className='hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-colors duration-200'
+            className='hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30 transition-colors duration-[var(--duration-base)]'
           >
             {t('clear')}
           </Button>

--- a/src/components/MapLastUpdated.tsx
+++ b/src/components/MapLastUpdated.tsx
@@ -70,7 +70,7 @@ const MapLastUpdated: React.FC<MapLastUpdatedProps> = ({ variant = 'map' }) => {
 
   return (
     <div className='absolute bottom-4 left-4 z-10'>
-      <span className='inline-flex items-center gap-2 rounded-lg bg-white border border-gray-200 px-3 py-2 text-xs font-medium text-gray-700 shadow-lg hover:shadow-xl transition-all duration-200 hover:bg-gray-50'>
+      <span className='inline-flex items-center gap-2 rounded-lg bg-white border border-gray-200 px-3 py-2 text-xs font-medium text-gray-700 shadow-lg hover:shadow-xl transition-all duration-[var(--duration-base)] hover:bg-gray-50'>
         <div className='w-2 h-2 bg-green-500 rounded-full animate-pulse'></div>
         {t('updatedAt')}: {formatTime()}
       </span>

--- a/src/components/MapThemeSelector.tsx
+++ b/src/components/MapThemeSelector.tsx
@@ -54,7 +54,11 @@ const MapThemeSelector: React.FC<MapThemeSelectorProps> = ({
             initial={{ opacity: 0, scale: 0.97, y: -6 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.97, y: -6 }}
-            transition={{ duration: 0.15, ease: 'easeOut' }}
+            // Motion (#200): mirrors CSS --duration-fast (150ms) and
+            // --ease-standard (cubic-bezier(0.4, 0, 0.2, 1)). There is no
+            // synced JS token file by design, so these numeric values are
+            // kept greppable against the CSS tokens they shadow.
+            transition={{ duration: 0.15, ease: [0.4, 0, 0.2, 1] }}
             // Trailhead (#213): no border, bigger radius + shadow, mirrors
             // the Select/DropdownMenu popover treatment.
             className='absolute right-0 top-full mt-2 w-80 max-w-[calc(100vw-2rem)] bg-popover rounded-2xl border-0 shadow-[0_4px_20px_rgba(0,0,0,0.16)] overflow-hidden z-30'

--- a/src/components/Mobile/MobileNavbar.tsx
+++ b/src/components/Mobile/MobileNavbar.tsx
@@ -8,10 +8,26 @@ import {
   BarChart2,
 } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { NAV_SURFACE_CLASS } from '@/lib/nav-surface';
+import { cn } from '@/lib/utils';
 import { motion } from 'framer-motion';
 import { shouldShowOfflineFeatures } from '@/lib/feature-flags';
 
 const basePath = import.meta.env.BASE_URL || '/';
+
+/**
+ * Section-adaptive accent: the active item's own tint, per CONTEXT.md.
+ *
+ * The `--happy-*` scale is light-mode only (see the note on it in index.css),
+ * so dark mode steps up to `--happy-500`. It has to: `--happy-700` over the
+ * translucent dark surface bottoms out at 1.7:1 against a light map, under WCAG
+ * 1.4.11's 3:1 floor for non-text contrast. `--happy-500` holds 5.9:1 at its
+ * worst. Exported so the test asserts the accent rather than a copied string.
+ */
+export const ACTIVE_ACCENT_CLASS =
+  'text-[var(--happy-700)] dark:text-[var(--happy-500)]';
+const INACTIVE_ACCENT_CLASS =
+  'text-muted-foreground hover:text-[var(--happy-700)] dark:hover:text-[var(--happy-500)]';
 const items = [
   { url: `${basePath}`, icon: Map },
   { url: `${basePath}worth-foraging-now`, icon: CalendarRange },
@@ -32,7 +48,13 @@ export default function MobileNavbar({ hidden }: MobileNavbarProps) {
 
   return (
     <motion.nav
-      className='fixed bottom-4 left-4 right-4 z-10'
+      // Raised + Glass-regular, shared with AppSidebar (#196). Carried on the
+      // animated element itself rather than an inner wrapper: a backdrop-filter
+      // nested inside a transformed ancestor samples the wrong region in Safari.
+      className={cn(
+        'fixed bottom-4 left-4 right-4 z-10 rounded-2xl',
+        NAV_SURFACE_CLASS
+      )}
       initial={{ y: 0 }}
       animate={{ y: hidden ? 120 : 0 }}
       transition={{
@@ -43,50 +65,48 @@ export default function MobileNavbar({ hidden }: MobileNavbarProps) {
         duration: 0.3,
       }}
     >
-      {/* Trailhead (#213). */}
-      <div className='bg-card rounded-2xl shadow-[0_2px_16px_rgba(0,0,0,0.10)]'>
-        <ul className='flex justify-around items-center py-3 px-3'>
-          {items.map(item => {
-            const isActive =
-              item.url === `${basePath}settings`
-                ? location.pathname.startsWith(`${basePath}settings`) ||
-                  (shouldShowOfflineFeatures &&
-                    location.pathname === `${basePath}offline`) ||
-                  location.pathname === `${basePath}instructions` ||
-                  location.pathname === `${basePath}support` ||
-                  location.pathname === `${basePath}impressum` ||
-                  location.pathname === `${basePath}privacy-policy` ||
-                  location.pathname === `${basePath}termsuse`
-                : location.pathname === item.url;
-            const Icon = item.icon;
-            return (
-              <li key={item.url} className='flex-1'>
-                <Link
-                  to={item.url}
-                  className={`flex flex-col items-center justify-center py-2 px-1 rounded-xl transition-all duration-[var(--duration-base)] ${
-                    isActive
-                      ? 'text-[var(--happy-700)]'
-                      : 'text-muted-foreground hover:text-[var(--happy-700)]'
-                  }`}
+      <ul className='flex justify-around items-center py-3 px-3'>
+        {items.map(item => {
+          const isActive =
+            item.url === `${basePath}settings`
+              ? location.pathname.startsWith(`${basePath}settings`) ||
+                (shouldShowOfflineFeatures &&
+                  location.pathname === `${basePath}offline`) ||
+                location.pathname === `${basePath}instructions` ||
+                location.pathname === `${basePath}support` ||
+                location.pathname === `${basePath}impressum` ||
+                location.pathname === `${basePath}privacy-policy` ||
+                location.pathname === `${basePath}termsuse`
+              : location.pathname === item.url;
+          const Icon = item.icon;
+          return (
+            <li key={item.url} className='flex-1'>
+              <Link
+                to={item.url}
+                // Section-adaptive accent is tint + scale only, so without
+                // this the active section is conveyed by colour alone.
+                aria-current={isActive ? 'page' : undefined}
+                className={`flex flex-col items-center justify-center py-2 px-1 rounded-xl transition-all duration-[var(--duration-base)] ${
+                  isActive ? ACTIVE_ACCENT_CLASS : INACTIVE_ACCENT_CLASS
+                }`}
+              >
+                <motion.div
+                  whileHover={{ scale: 1.1 }}
+                  whileTap={{ scale: 0.95 }}
+                  animate={isActive ? { scale: 1.2 } : { scale: 1 }}
+                  transition={{
+                    type: 'spring',
+                    stiffness: 400,
+                    damping: 25,
+                  }}
                 >
-                  <motion.div
-                    whileHover={{ scale: 1.1 }}
-                    whileTap={{ scale: 0.95 }}
-                    animate={isActive ? { scale: 1.2 } : { scale: 1 }}
-                    transition={{
-                      type: 'spring',
-                      stiffness: 400,
-                      damping: 25,
-                    }}
-                  >
-                    <Icon className='h-6 w-6' />
-                  </motion.div>
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
+                  <Icon className='h-6 w-6' />
+                </motion.div>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
     </motion.nav>
   );
 }

--- a/src/components/Mobile/MobileNavbar.tsx
+++ b/src/components/Mobile/MobileNavbar.tsx
@@ -39,6 +39,7 @@ export default function MobileNavbar({ hidden }: MobileNavbarProps) {
         type: 'spring',
         stiffness: 300,
         damping: 30,
+        // Motion (#200): mirrors CSS --duration-slow (300ms).
         duration: 0.3,
       }}
     >
@@ -62,7 +63,7 @@ export default function MobileNavbar({ hidden }: MobileNavbarProps) {
               <li key={item.url} className='flex-1'>
                 <Link
                   to={item.url}
-                  className={`flex flex-col items-center justify-center py-2 px-1 rounded-xl transition-all duration-200 ${
+                  className={`flex flex-col items-center justify-center py-2 px-1 rounded-xl transition-all duration-[var(--duration-base)] ${
                     isActive
                       ? 'text-[var(--happy-700)]'
                       : 'text-muted-foreground hover:text-[var(--happy-700)]'

--- a/src/components/Sidebar/AppSidebar.tsx
+++ b/src/components/Sidebar/AppSidebar.tsx
@@ -24,6 +24,7 @@ import { NavMain } from './nav-main';
 import { useTranslation } from 'react-i18next';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { shouldShowOfflineFeatures } from '@/lib/feature-flags';
+import { NAV_SURFACE_CLASS } from '@/lib/nav-surface';
 import MapLastUpdated from '@/components/MapLastUpdated';
 
 const basePath = import.meta.env.BASE_URL || '/';
@@ -128,7 +129,12 @@ export const AppSidebar = (props: React.ComponentProps<typeof Sidebar>) => {
     <Sidebar
       variant='floating'
       collapsible='offcanvas'
-      className='bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'
+      // shadcn's `variant='floating'` is layout/shape only; the elevation level
+      // here is Raised, shared with MobileNavbar. See CONTEXT.md's note on the
+      // naming collision. This replaces a hand-rolled
+      // `bg-background/95 backdrop-blur` that sat on the positioning container
+      // and so was painted over by the surface's own opaque background.
+      surfaceClassOverride={NAV_SURFACE_CLASS}
       {...props}
     >
       <SidebarHeader className='border-b px-6 py-4'>

--- a/src/components/Sidebar/nav-main.tsx
+++ b/src/components/Sidebar/nav-main.tsx
@@ -95,7 +95,7 @@ export function NavMain({
                   <SidebarMenuButton tooltip={item.title} isActive={isActive}>
                     {item.icon && <item.icon />}
                     <span>{item.title}</span>
-                    <ChevronRight className='ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90' />
+                    <ChevronRight className='ml-auto transition-transform duration-[var(--duration-base)] group-data-[state=open]/collapsible:rotate-90' />
                   </SidebarMenuButton>
                 </CollapsibleTrigger>
                 <CollapsibleContent>

--- a/src/components/Sidebar/nav-main.tsx
+++ b/src/components/Sidebar/nav-main.tsx
@@ -73,7 +73,10 @@ export function NavMain({
                   tooltip={item.title}
                   isActive={isActive}
                 >
-                  <Link to={item.url}>
+                  <Link
+                    to={item.url}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
                     {item.icon && <item.icon />}
                     <span>{item.title}</span>
                   </Link>

--- a/src/components/Sidebar/nav-secondary.tsx
+++ b/src/components/Sidebar/nav-secondary.tsx
@@ -39,7 +39,10 @@ export function NavSecondary({
                   isActive={isActive}
                   onClick={item.onClick}
                 >
-                  <Link to={item.url}>
+                  <Link
+                    to={item.url}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
                     <item.icon />
                     <span>{item.title}</span>
                   </Link>

--- a/src/components/SpeciesSelector.tsx
+++ b/src/components/SpeciesSelector.tsx
@@ -53,7 +53,7 @@ const SpeciesSelector: React.FC<SpeciesSelectorProps> = ({
           onClick={() => setIsOpen(!isOpen)}
           // Trailhead (#213): floating map control — no border, soft shadow.
           className={cn(
-            'flex items-center border-0 bg-card/95 backdrop-blur-sm hover:bg-[var(--happy-50)]/95 transition-all duration-200 shadow-[0_2px_10px_rgba(0,0,0,0.18)]',
+            'flex items-center border-0 bg-card/95 backdrop-blur-sm hover:bg-[var(--happy-50)]/95 transition-all duration-[var(--duration-base)] shadow-[0_2px_10px_rgba(0,0,0,0.18)]',
             'h-16 px-2 py-2 rounded-2xl',
             isOpen && 'bg-[var(--happy-50)]/95'
           )}
@@ -61,6 +61,7 @@ const SpeciesSelector: React.FC<SpeciesSelectorProps> = ({
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.95 }}
           transition={{
+            // Motion (#200): mirrors CSS --duration-base (200ms).
             duration: 0.2,
             type: 'spring',
             stiffness: 400,
@@ -106,7 +107,7 @@ const SpeciesSelector: React.FC<SpeciesSelectorProps> = ({
           onClick={() => setIsOpen(!isOpen)}
           // Trailhead (#213): floating map control — no border, soft shadow.
           className={cn(
-            'justify-between border-0 bg-card/95 backdrop-blur-sm hover:bg-[var(--happy-50)]/95 transition-all duration-200 shadow-[0_2px_10px_rgba(0,0,0,0.18)] rounded-full',
+            'justify-between border-0 bg-card/95 backdrop-blur-sm hover:bg-[var(--happy-50)]/95 transition-all duration-[var(--duration-base)] shadow-[0_2px_10px_rgba(0,0,0,0.18)] rounded-full',
             'w-72 min-h-[32px] px-3 py-1',
             isOpen && 'bg-[var(--happy-50)]/95'
           )}
@@ -114,6 +115,7 @@ const SpeciesSelector: React.FC<SpeciesSelectorProps> = ({
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.95 }}
           transition={{
+            // Motion (#200): mirrors CSS --duration-base (200ms).
             duration: 0.2,
             type: 'spring',
             stiffness: 400,
@@ -127,7 +129,7 @@ const SpeciesSelector: React.FC<SpeciesSelectorProps> = ({
           </div>
           <ChevronDown
             className={cn(
-              'transition-transform duration-200 flex-shrink-0',
+              'transition-transform duration-[var(--duration-base)] flex-shrink-0',
               'h-3 w-3',
               isOpen ? 'rotate-180' : ''
             )}

--- a/src/components/SpeciesSelectorFullscreen.tsx
+++ b/src/components/SpeciesSelectorFullscreen.tsx
@@ -125,6 +125,8 @@ const SpeciesSelectorFullscreen: React.FC<SpeciesSelectorFullscreenProps> = ({
       animate={{ opacity: 1, scale: 1, y: 0 }}
       exit={{ opacity: 0, scale: 0.8, y: 20 }}
       transition={{
+        // Motion (#200): mirrors CSS --duration-base (200ms) and
+        // --ease-standard (cubic-bezier(0.4, 0, 0.2, 1)).
         duration: 0.2,
         ease: [0.4, 0.0, 0.2, 1],
       }}
@@ -152,7 +154,7 @@ const SpeciesSelectorFullscreen: React.FC<SpeciesSelectorFullscreenProps> = ({
           variant='ghost'
           size='sm'
           onClick={onClose}
-          className='h-10 w-10 p-0 bg-white/20 hover:bg-white/40 text-white border border-white/30 hover:border-white/50 transition-all duration-200 flex-shrink-0'
+          className='h-10 w-10 p-0 bg-white/20 hover:bg-white/40 text-white border border-white/30 hover:border-white/50 transition-all duration-[var(--duration-base)] flex-shrink-0'
         >
           <X className='h-5 w-5' />
         </Button>
@@ -169,7 +171,7 @@ const SpeciesSelectorFullscreen: React.FC<SpeciesSelectorFullscreenProps> = ({
               // neutral fill as unselected, marked by weight only (no
               // colour swap), no border.
               className={cn(
-                'flex items-center gap-2 px-3 py-2 rounded-full text-sm transition-all duration-200 border-0 backdrop-blur-sm',
+                'flex items-center gap-2 px-3 py-2 rounded-full text-sm transition-all duration-[var(--duration-base)] border-0 backdrop-blur-sm',
                 selectedCategory === category.value
                   ? 'bg-white text-gray-900 font-semibold shadow-[0_1px_4px_rgba(0,0,0,0.08)]'
                   : 'bg-white/90 text-gray-700 font-medium hover:bg-white'
@@ -243,7 +245,7 @@ const SpeciesSelectorFullscreen: React.FC<SpeciesSelectorFullscreenProps> = ({
                     // Trailhead (#213): no border — selection is a shadow
                     // lift + tint + the corner checkmark badge, not a ring.
                     className={cn(
-                      'group relative bg-white rounded-2xl border-0 transition-all duration-200 hover:shadow-[0_6px_20px_rgba(0,0,0,0.14)]',
+                      'group relative bg-white rounded-2xl border-0 transition-all duration-[var(--duration-base)] hover:shadow-[0_6px_20px_rgba(0,0,0,0.14)]',
                       'p-4 text-center min-h-[140px] flex flex-col items-center justify-center',
                       'hover:scale-105 active:scale-95',
                       disabled
@@ -264,7 +266,7 @@ const SpeciesSelectorFullscreen: React.FC<SpeciesSelectorFullscreenProps> = ({
                     <div
                       className={cn(
                         'relative w-16 h-16 bg-gradient-to-br from-green-50 to-green-100 overflow-hidden rounded-lg mb-3',
-                        'flex-shrink-0 transition-transform duration-200 group-hover:scale-110'
+                        'flex-shrink-0 transition-transform duration-[var(--duration-base)] group-hover:scale-110'
                       )}
                     >
                       {getSpeciesImage(species.code) ? (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -31,7 +31,7 @@ const buttonVariants = cva(
         outline:
           'rounded-full border-2 border-primary bg-transparent text-[var(--happy-700)] shadow-none hover:bg-[var(--happy-50)] hover:text-[var(--happy-700)] dark:border-primary dark:bg-card dark:text-primary dark:hover:bg-primary dark:hover:text-primary-foreground',
         'enhanced-outline':
-          'border-2 border-primary bg-white text-primary shadow-md hover:bg-primary hover:text-white hover:shadow-lg transition-all duration-200 dark:border-primary dark:bg-card dark:text-primary dark:hover:bg-primary dark:hover:text-primary-foreground',
+          'border-2 border-primary bg-white text-primary shadow-md hover:bg-primary hover:text-white hover:shadow-lg transition-all duration-[var(--duration-base)] dark:border-primary dark:bg-card dark:text-primary dark:hover:bg-primary dark:hover:text-primary-foreground',
         secondary:
           'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         // dark: classes unchanged — Trailhead wasn't reviewed in dark mode.

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,8 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot='dialog-overlay'
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        // Motion (#200): scrim matches the content's --duration-base.
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 duration-[var(--duration-base)] ease-standard',
         className
       )}
       {...props}
@@ -60,8 +61,10 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot='dialog-content'
         className={cn(
-          // Trailhead (#213): no border, bigger radius + shadow.
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border-0 p-6 shadow-[0_8px_32px_rgba(0,0,0,0.24)] duration-200 sm:max-w-lg',
+          // Trailhead (#213): no border, bigger radius + shadow. The shadow
+          // is now the `overlay` elevation token (#200 / ADR 0001), whose
+          // value is Trailhead's own — same pixels, one source of truth.
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border-0 elevation-overlay p-6 duration-[var(--duration-base)] ease-standard sm:max-w-lg',
           className
         )}
         {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -35,7 +35,8 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot='sheet-overlay'
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        // Motion (#200): scrim matches the panel's --duration-slow.
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 duration-[var(--duration-slow)] ease-standard',
         className
       )}
       {...props}
@@ -59,7 +60,10 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot='sheet-content'
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          // Motion (#200): Sheet is a `floating` surface, so enter and exit
+          // both ride --duration-slow. The asymmetric 500ms open is folded
+          // onto the shared scale — one scale, no undocumented exception.
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out elevation-floating fixed z-50 flex flex-col gap-4 transition duration-[var(--duration-slow)] ease-standard',
           side === 'right' &&
             'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
           side === 'left' &&

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -155,12 +155,24 @@ function Sidebar({
   variant = 'sidebar',
   collapsible = 'offcanvas',
   className,
+  surfaceClassOverride,
   children,
   ...props
 }: React.ComponentProps<'div'> & {
   side?: 'left' | 'right';
   variant?: 'sidebar' | 'floating' | 'inset';
   collapsible?: 'offcanvas' | 'icon' | 'none';
+  /**
+   * Classes for the painted surface rather than the positioning container that
+   * `className` targets. Supplying this replaces shadcn's default background,
+   * border and shadow wholesale — the point is to let a consumer apply the
+   * app's own elevation/glass treatment (#200) without those defaults, which
+   * live in Tailwind's utilities layer, winning over it.
+   *
+   * Applies to the desktop rail only. The mobile branch is a Sheet, which is
+   * elevation level Floating rather than Raised, so it keeps its own styling.
+   */
+  surfaceClassOverride?: string;
 }) {
   const { t } = useTranslation('common');
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
@@ -244,7 +256,11 @@ function Sidebar({
         <div
           data-sidebar='sidebar'
           data-slot='sidebar-inner'
-          className='bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm'
+          className={cn(
+            'flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg',
+            surfaceClassOverride ??
+              'bg-sidebar group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm'
+          )}
         >
           {children}
         </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -218,7 +218,7 @@ function Sidebar({
       <div
         data-slot='sidebar-gap'
         className={cn(
-          'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
+          'relative w-(--sidebar-width) bg-transparent transition-[width] duration-[var(--duration-base)] ease-linear',
           'group-data-[collapsible=offcanvas]:w-0',
           'group-data-[side=right]:rotate-180',
           variant === 'floating' || variant === 'inset'
@@ -229,7 +229,7 @@ function Sidebar({
       <div
         data-slot='sidebar-container'
         className={cn(
-          'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
+          'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-[var(--duration-base)] ease-linear md:flex',
           side === 'left'
             ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
             : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
@@ -406,7 +406,7 @@ function SidebarGroupLabel({
       data-slot='sidebar-group-label'
       data-sidebar='group-label'
       className={cn(
-        'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear [&>svg]:size-4 [&>svg]:shrink-0',
+        'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-[var(--duration-base)] ease-linear [&>svg]:size-4 [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -76,6 +76,11 @@
   --color-warning: var(--status-warning);
   --color-status-warning-text: var(--status-warning-text);
   --color-status-warning-border: var(--status-warning-border);
+
+  /* Motion easing (#200). Registered here so Tailwind emits an `ease-standard`
+     utility. Durations are not a Tailwind theme namespace, so they live in
+     :root and are consumed via arbitrary values — see --duration-* below. */
+  --ease-standard: var(--ease-standard);
 }
 
 :root {
@@ -217,6 +222,55 @@
     0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
   --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
   --tracking-normal: 0em;
+
+  /* ------------------------------------------------------------------
+     Motion scale (#200)
+     Three durations and one easing curve. Every transition in the app
+     should reference these rather than hardcoding a value.
+     ------------------------------------------------------------------ */
+  --duration-fast: 150ms; /* elevation hover/press micro-interactions */
+  --duration-base: 200ms; /* canonical; default UI state changes */
+  --duration-slow: 300ms; /* floating/overlay enter-exit (Dialog, Sheet) */
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ------------------------------------------------------------------
+     Glass surfaces (#200) — light theme
+     Opt-in, and only on `raised`/`floating` chrome. Never on `base`
+     (the map canvas) or `overlay` (blocking dialogs), which must stay
+     opaque for WCAG 1.4.11 contrast over the busy map background.
+     ------------------------------------------------------------------ */
+  --glass-blur-regular: 12px;
+  --glass-blur-clear: 16px;
+  --glass-bg-regular: rgb(255 255 255 / 0.9);
+  --glass-bg-clear: rgb(255 255 255 / 0.12);
+  --glass-border: rgb(255 255 255 / 0.3);
+  /* Stands in for Liquid Glass's specular highlight, which #193 confirmed
+     isn't feasible on the web. Doubles as the dark-mode depth cue below. */
+  --glass-highlight: rgb(255 255 255 / 0.5);
+
+  /* Opaque equivalents, used when backdrop-filter is unsupported or the
+     user asks for reduced transparency / increased contrast. */
+  --glass-bg-regular-opaque: var(--card);
+  --glass-bg-clear-opaque: var(--card);
+
+  /* ------------------------------------------------------------------
+     Elevation levels (#200) — light theme
+
+     Per ADR 0001, these are NOT aliases of the --shadow-* scale: that
+     scale predates Trailhead (#213) and is materially weaker than what
+     Trailhead already ships, so aliasing it would regress the live look.
+     The values below are Trailhead's shipped shadows, lifted verbatim and
+     canonicalized here as the single source of truth.
+
+     `base` is deliberately absent — the map canvas is not a discrete
+     surface and carries no shadow. Level definitions live in CONTEXT.md's
+     design-system glossary.
+     ------------------------------------------------------------------ */
+  --elevation-raised-subtle: 0 1px 6px rgba(0, 0, 0, 0.06); /* Input, Select trigger */
+  --elevation-raised: 0 2px 16px rgba(0, 0, 0, 0.1); /* Card, MobileNavbar */
+  --elevation-raised-hover: 0 6px 20px rgba(0, 0, 0, 0.14); /* Card hover escalation */
+  --elevation-floating: 0 4px 20px rgba(0, 0, 0, 0.16); /* DropdownMenu, Select content */
+  --elevation-overlay: 0 8px 32px rgba(0, 0, 0, 0.24); /* Dialog */
 }
 
 .dark {
@@ -290,6 +344,36 @@
   --shadow-xl:
     0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
   --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+
+  /* ------------------------------------------------------------------
+     Glass surfaces (#200) — dark theme
+     ------------------------------------------------------------------ */
+  --glass-bg-regular: color-mix(in oklch, var(--card) 80%, transparent);
+  --glass-bg-clear: rgb(0 0 0 / 0.2);
+  --glass-border: rgb(255 255 255 / 0.1);
+  --glass-highlight: rgb(255 255 255 / 0.08);
+  /* The *-opaque fallbacks are not restated here: they resolve through
+     var(--card), which the dark block already redefines above. */
+
+  /* ------------------------------------------------------------------
+     Elevation levels (#200) — dark theme
+
+     Same geometry as the light values above (identical offset/blur, so
+     the levels stay recognisably one scale); only the alpha deepens,
+     because a 0.06–0.24 black shadow is invisible against a dark
+     background. Per ADR 0001 the 1px inset --glass-highlight is the real
+     depth cue here and the drop shadow is secondary.
+     ------------------------------------------------------------------ */
+  --elevation-raised-subtle:
+    inset 0 1px 0 0 var(--glass-highlight), 0 1px 6px rgba(0, 0, 0, 0.3);
+  --elevation-raised:
+    inset 0 1px 0 0 var(--glass-highlight), 0 2px 16px rgba(0, 0, 0, 0.4);
+  --elevation-raised-hover:
+    inset 0 1px 0 0 var(--glass-highlight), 0 6px 20px rgba(0, 0, 0, 0.5);
+  --elevation-floating:
+    inset 0 1px 0 0 var(--glass-highlight), 0 4px 20px rgba(0, 0, 0, 0.55);
+  --elevation-overlay:
+    inset 0 1px 0 0 var(--glass-highlight), 0 8px 32px rgba(0, 0, 0, 0.65);
 }
 
 @layer base {

--- a/src/lib/nav-surface.ts
+++ b/src/lib/nav-surface.ts
@@ -1,0 +1,16 @@
+/**
+ * The single place the nav chrome's surface treatment is spelled out.
+ *
+ * `AppSidebar` (desktop) and `MobileNavbar` (mobile) are both elevation level
+ * **Raised** with **Glass-regular** applied — see the design-system glossary in
+ * `CONTEXT.md`. Neither is *Floating* in the elevation sense: that level is
+ * reserved for dismiss-by-tap-outside surfaces (menus, sheets, tooltips), and
+ * both of these are persistent primary nav even though the mobile bar visually
+ * sits over the map.
+ *
+ * The two consume this constant instead of each spelling the classes out so
+ * that the platforms' chrome can't silently drift apart. The utilities
+ * themselves are defined in `src/styles/globals.scss` (#200); this only names
+ * them.
+ */
+export const NAV_SURFACE_CLASS = 'elevation-raised glass-regular';

--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -271,7 +271,7 @@ interface ChartCardProps {
 
 function ChartCard({ title, children }: ChartCardProps) {
   return (
-    <Card className='py-6 shadow-sm hover:shadow-md transition-shadow duration-200'>
+    <Card className='py-6 shadow-sm hover:shadow-md transition-shadow duration-[var(--duration-base)]'>
       <CardHeader className='pb-2'>
         <CardTitle className='text-sm font-medium text-muted-foreground'>
           {title}

--- a/src/pages/SpeciesPage.tsx
+++ b/src/pages/SpeciesPage.tsx
@@ -144,7 +144,7 @@ export default function SpeciesPage() {
             return (
               <Card
                 key={species.id}
-                className='hover:shadow-lg transition-shadow duration-200 py-6'
+                className='hover:shadow-lg transition-shadow duration-[var(--duration-base)] py-6'
               >
                 <CardHeader className='pb-3'>
                   <div className='flex items-start gap-4'>

--- a/src/pages/SupportPage.tsx
+++ b/src/pages/SupportPage.tsx
@@ -101,7 +101,7 @@ export default function SupportPage() {
               {platformMethods.map(method => (
                 <Card
                   key={method.id}
-                  className='p-6 cursor-pointer hover:shadow-lg transition-all duration-200 border-2 hover:border-primary/20'
+                  className='p-6 cursor-pointer hover:shadow-lg transition-all duration-[var(--duration-base)] border-2 hover:border-primary/20'
                   onClick={() => handleDonationClick(method)}
                 >
                   <div className='flex items-center justify-between mb-4'>

--- a/src/stories/Card.stories.tsx
+++ b/src/stories/Card.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
 import {
   Card,
   CardHeader,
@@ -420,5 +421,200 @@ export const HorizontalLayout: Story = {
   ),
   parameters: {
     layout: 'padded',
+  },
+};
+
+/* ---------------------------------------------------------------------------
+ * Elevation & glass tokens (#200)
+ *
+ * These stories are the visual seam for the elevation-level and glass-variant
+ * token system. They deliberately assert only that the surfaces render — the
+ * raw token values (oklch numbers, cubic-bezier strings) are implementation
+ * detail and are checked by eye in Storybook, not by string comparison.
+ * ------------------------------------------------------------------------- */
+
+/** Renders children twice: once in the light theme, once inside `.dark`. */
+const ThemeMatrix = ({ children }: { children: React.ReactNode }) => (
+  <div className='grid grid-cols-1 gap-0 sm:grid-cols-2'>
+    <div className='bg-background text-foreground flex flex-col gap-6 p-8'>
+      <p className='text-muted-foreground text-xs font-medium tracking-wide uppercase'>
+        {'Light'}
+      </p>
+      {children}
+    </div>
+    <div className='dark bg-background text-foreground flex flex-col gap-6 p-8'>
+      <p className='text-muted-foreground text-xs font-medium tracking-wide uppercase'>
+        {'Dark'}
+      </p>
+      {children}
+    </div>
+  </div>
+);
+
+const ELEVATION_LEVELS = [
+  {
+    name: 'base',
+    className: '',
+    blurb: 'The map canvas. No shadow, no glass — not a discrete surface.',
+  },
+  {
+    name: 'raised-subtle',
+    className: 'elevation-raised-subtle',
+    blurb: 'Lightweight input chrome: search field, Select trigger.',
+  },
+  {
+    name: 'raised',
+    className: 'elevation-raised',
+    blurb: 'Small static chrome: Card, AppSidebar, MobileNavbar.',
+  },
+  {
+    name: 'floating',
+    className: 'elevation-floating',
+    blurb: 'Dismiss-by-tap-outside overlays: Sheet, Popover, DropdownMenu.',
+  },
+  {
+    name: 'overlay',
+    className: 'elevation-overlay',
+    blurb: 'Blocking Dialogs with a scrim. Always opaque, never glass.',
+  },
+] as const;
+
+export const ElevationLevels: Story = {
+  render: () => (
+    <ThemeMatrix>
+      {ELEVATION_LEVELS.map(level => (
+        <Card key={level.name} className={`w-[320px] ${level.className}`}>
+          <CardHeader>
+            <CardTitle className='font-mono text-sm'>{level.name}</CardTitle>
+            <CardDescription>{level.blurb}</CardDescription>
+          </CardHeader>
+        </Card>
+      ))}
+    </ThemeMatrix>
+  ),
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'The four semantic elevation levels, in both themes. Dark mode leans on the 1px inset --glass-highlight for depth, since the --shadow-* scale is identical across themes.',
+      },
+    },
+  },
+};
+
+/**
+ * Glass needs something textured behind it to read as translucent, so both
+ * glass stories sit on a striped backdrop standing in for the map canvas.
+ */
+const MapBackdrop = ({ children }: { children: React.ReactNode }) => (
+  <div
+    className='flex min-h-[220px] items-center justify-center rounded-xl p-8'
+    style={{
+      backgroundImage:
+        'repeating-linear-gradient(45deg, oklch(0.72 0.11 147) 0 18px, oklch(0.62 0.13 165) 18px 36px)',
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const GlassRegular: Story = {
+  render: () => (
+    <ThemeMatrix>
+      <MapBackdrop>
+        <div className='glass-regular elevation-raised w-[280px] rounded-xl p-5'>
+          <p className='font-display text-base font-semibold'>
+            {'Glass regular'}
+          </p>
+          <p className='text-muted-foreground mt-1 text-sm'>
+            {'12px blur. For fixed chrome sitting over the map or text.'}
+          </p>
+        </div>
+      </MapBackdrop>
+    </ThemeMatrix>
+  ),
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'The `glass-regular` variant at the `raised` level, over a stand-in map backdrop. Opt-in per component and restricted to small fixed-size chrome.',
+      },
+    },
+  },
+};
+
+export const GlassClear: Story = {
+  render: () => (
+    <ThemeMatrix>
+      <MapBackdrop>
+        <div className='glass-clear elevation-raised w-[280px] rounded-xl p-5'>
+          <p className='font-display text-base font-semibold'>
+            {'Glass clear'}
+          </p>
+          <p className='mt-1 text-sm'>
+            {'16px blur. Full-bleed media backgrounds only.'}
+          </p>
+        </div>
+      </MapBackdrop>
+    </ThemeMatrix>
+  ),
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'The `glass-clear` variant — markedly more transparent, and reserved for full-bleed media. Never place text-heavy, contrast-critical content on it.',
+      },
+    },
+  },
+};
+
+export const GlassInteractive: Story = {
+  render: () => (
+    <MapBackdrop>
+      <button
+        type='button'
+        data-testid='glass-interactive'
+        className='glass-regular elevation-raised elevation-interactive w-[280px] cursor-pointer rounded-xl p-5 text-left'
+      >
+        <span className='font-display block text-base font-semibold'>
+          {'Interactive glass chrome'}
+        </span>
+        <span className='text-muted-foreground mt-1 block text-sm'>
+          {'Hover and press shift the shadow over --duration-fast.'}
+        </span>
+      </button>
+    </MapBackdrop>
+  ),
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        story:
+          'Exercises the motion tokens (--duration-fast, --ease-standard) through real hover/press behaviour on a `raised` glass surface.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const surface = canvas.getByTestId('glass-interactive');
+
+    await expect(surface).toBeInTheDocument();
+
+    // The transition itself is what the motion tokens drive, so assert the
+    // element actually declares one rather than pinning the literal ms value.
+    const transition = getComputedStyle(surface).transitionDuration;
+    await expect(transition).not.toBe('');
+    await expect(transition).not.toBe('0s');
+
+    await userEvent.hover(surface);
+    await expect(surface).toBeVisible();
+
+    await userEvent.click(surface);
+    await expect(surface).toBeVisible();
+
+    await userEvent.unhover(surface);
   },
 };

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -112,6 +112,21 @@
       background: var(--muted-foreground);
     }
   }
+
+  // Motion (#200): honour the OS-level reduced-motion preference app-wide.
+  // Non-essential transitions and decorative animations are collapsed to
+  // effectively zero rather than shortened, so the state change still lands
+  // — it just lands without the animation.
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 }
 
 // Component-specific styles
@@ -267,6 +282,133 @@
       width: 60vw;
       max-width: 550px;
       height: auto;
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Elevation levels (#200)
+  //
+  // Semantic depth roles composed from the --elevation-* tokens defined in
+  // index.css. Pick the role, not a raw shadow. Definitions are the ones in
+  // CONTEXT.md's design-system glossary:
+  //
+  //   base           - the map canvas. No class, no shadow: not a discrete
+  //                    surface, so it deliberately has no utility here.
+  //   raised-subtle  - lightweight input chrome you look through rather
+  //                    than press (search field, Select trigger). No hover
+  //                    escalation.
+  //   raised         - small, static, fixed-size chrome (Card, AppSidebar,
+  //                    MobileNavbar).
+  //   floating       - dismiss-by-tap-outside surfaces (Sheet, Popover,
+  //                    DropdownMenu, tooltip).
+  //   overlay        - blocking surfaces with a scrim (modal Dialog).
+  //
+  // In dark mode each carries a 1px inset --glass-highlight, which is what
+  // actually reads as depth there; the drop shadow is secondary. See
+  // ADR 0001 for why these values are Trailhead's rather than --shadow-*.
+  // ---------------------------------------------------------------------
+  .elevation-raised-subtle {
+    box-shadow: var(--elevation-raised-subtle);
+  }
+
+  .elevation-raised {
+    box-shadow: var(--elevation-raised);
+  }
+
+  .elevation-floating {
+    box-shadow: var(--elevation-floating);
+  }
+
+  .elevation-overlay {
+    box-shadow: var(--elevation-overlay);
+  }
+
+  // ---------------------------------------------------------------------
+  // Glass surfaces (#200)
+  //
+  // Scope rule: opt-in per component, and only on small, fixed-size chrome
+  // at the `raised` or `floating` level. Never on `base` (the map canvas),
+  // never on `overlay` (Dialogs are text-heavy and contrast-critical over a
+  // busy, variable map background — WCAG 1.4.11 risk), and never on
+  // anything large or that animates its own size.
+  //
+  // Both variants degrade to an opaque background whenever backdrop-filter
+  // is unavailable or the user has asked for less transparency / more
+  // contrast. The opaque path is the default here and the translucent path
+  // is layered on top, so an unsupporting browser never renders
+  // near-invisible chrome.
+  // ---------------------------------------------------------------------
+  .glass-regular,
+  .glass-clear {
+    border: 1px solid var(--glass-border);
+    // Shares --glass-highlight with the --elevation-* tokens: on glass it
+    // stands in for Liquid Glass's specular edge. Carried on the top border
+    // rather than an inset box-shadow so that pairing a glass class with an
+    // .elevation-* class doesn't have the two fight over box-shadow.
+    border-top-color: var(--glass-highlight);
+  }
+
+  .glass-regular {
+    background-color: var(--glass-bg-regular-opaque);
+  }
+
+  .glass-clear {
+    background-color: var(--glass-bg-clear-opaque);
+  }
+
+  @supports (backdrop-filter: blur(1px)) {
+    .glass-regular {
+      background-color: var(--glass-bg-regular);
+      backdrop-filter: blur(var(--glass-blur-regular));
+    }
+
+    // Reserved for full-bleed media backgrounds. Never place text-heavy
+    // content on this variant.
+    .glass-clear {
+      background-color: var(--glass-bg-clear);
+      backdrop-filter: blur(var(--glass-blur-clear));
+    }
+  }
+
+  // Accessibility fallbacks: drop the blur entirely and go opaque. Both
+  // preferences want the same outcome, so they share one rule.
+  @media (prefers-reduced-transparency: reduce), (prefers-contrast: more) {
+    .glass-regular {
+      background-color: var(--glass-bg-regular-opaque);
+      backdrop-filter: none;
+    }
+
+    .glass-clear {
+      background-color: var(--glass-bg-clear-opaque);
+      backdrop-filter: none;
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Elevation hover/press feedback (#200)
+  //
+  // Opt-in on interactive `raised` chrome. Shifts shadow and background
+  // only — no scale or transform.
+  // ---------------------------------------------------------------------
+  .elevation-interactive {
+    transition:
+      box-shadow var(--duration-fast) var(--ease-standard),
+      background-color var(--duration-fast) var(--ease-standard);
+
+    &:hover {
+      box-shadow: var(--elevation-raised-hover);
+    }
+
+    &:active {
+      box-shadow: var(--elevation-raised);
+    }
+  }
+
+  // Non-essential motion (hover feedback, decorative fades) is removed
+  // outright rather than shortened; the state change still lands.
+  @media (prefers-reduced-motion: reduce) {
+    .elevation-interactive {
+      transition: none;
     }
   }
 }

--- a/src/test/AppSidebar.test.tsx
+++ b/src/test/AppSidebar.test.tsx
@@ -1,0 +1,180 @@
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@/i18n';
+import { AppSidebar } from '@/components/Sidebar/AppSidebar';
+import { SidebarProvider, useSidebar } from '@/components/ui/sidebar';
+import { NAV_SURFACE_CLASS } from '@/lib/nav-surface';
+
+/**
+ * `AppSidebar` decides its own item set from platform and feature flags —
+ * relevance-based disclosure, per CONTEXT.md. That's the behaviour worth
+ * pinning: which entries a given platform/flag combination renders, and which
+ * one reads as active. `NavMain`/`NavSecondary` are exercised through the
+ * sidebar rather than tested in isolation, since the item list is what they
+ * exist to render.
+ */
+
+const { pathname } = vi.hoisted(() => ({ pathname: { current: '/' } }));
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => ({ pathname: pathname.current }),
+  Link: ({
+    to,
+    children,
+    ...props
+  }: {
+    to: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const { isMobile } = vi.hoisted(() => ({ isMobile: { current: false } }));
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => isMobile.current,
+}));
+
+const { offlineEnabled } = vi.hoisted(() => ({
+  offlineEnabled: { current: false },
+}));
+vi.mock('@/lib/feature-flags', () => ({
+  get shouldShowOfflineFeatures() {
+    return offlineEnabled.current;
+  },
+}));
+
+/**
+ * On mobile `Sidebar` becomes an off-canvas Sheet that starts closed, so its
+ * items aren't in the DOM until it opens. Nothing in the app renders a
+ * `SidebarTrigger` today (mobile navigation goes through `MobileNavbar`
+ * instead), so the mobile item set is opened here directly — the disclosure
+ * logic under test lives in `AppSidebar`, not in what opens the sheet.
+ */
+const OpenMobileSheet = () => {
+  const { setOpenMobile } = useSidebar();
+  React.useEffect(() => setOpenMobile(true), [setOpenMobile]);
+  return null;
+};
+
+const renderSidebar = () =>
+  render(
+    <SidebarProvider>
+      {isMobile.current && <OpenMobileSheet />}
+      <AppSidebar />
+    </SidebarProvider>
+  );
+
+const navLinks = () =>
+  screen.getAllByRole('link').map(link => link.getAttribute('href') ?? '');
+
+beforeEach(() => {
+  pathname.current = '/';
+  isMobile.current = false;
+  offlineEnabled.current = false;
+});
+
+describe('AppSidebar', () => {
+  it('shows every top-level section on desktop without extra taps', () => {
+    renderSidebar();
+
+    expect(navLinks()).toEqual([
+      '/',
+      '/worth-foraging-now',
+      '/species',
+      '/data',
+      '/recipes',
+      '/instructions',
+      '/support',
+      '/impressum',
+      '/privacy-policy',
+      '/termsuse',
+    ]);
+  });
+
+  it('adds Offline Maps on desktop once the flag is enabled', () => {
+    offlineEnabled.current = true;
+    renderSidebar();
+
+    expect(navLinks()).toContain('/offline');
+  });
+
+  it('hides Offline Maps entirely while the flag is off', () => {
+    renderSidebar();
+
+    expect(navLinks()).not.toContain('/offline');
+  });
+
+  it('does not show Offline Maps on mobile even with the flag enabled', () => {
+    // The mobile item set is deliberately the short one; offline maps live
+    // behind Settings there.
+    offlineEnabled.current = true;
+    isMobile.current = true;
+    renderSidebar();
+
+    expect(navLinks()).not.toContain('/offline');
+  });
+
+  it('trades Instructions and the legal links for Settings on mobile', () => {
+    isMobile.current = true;
+    renderSidebar();
+
+    expect(navLinks()).toEqual([
+      '/',
+      '/worth-foraging-now',
+      '/species',
+      '/data',
+      '/recipes',
+      '/settings',
+    ]);
+  });
+
+  it('marks the entry for the current route as active', () => {
+    pathname.current = '/data';
+    renderSidebar();
+
+    const active = document.querySelectorAll('a[aria-current="page"]');
+    expect(active).toHaveLength(1);
+    expect(active[0]).toHaveAttribute('href', '/data');
+  });
+
+  it('gives the active entry the accent styling and no other entry', () => {
+    // The sidebar's accent rides on shadcn's `data-active`, which drives the
+    // theme-aware --sidebar-accent-foreground tint. Unlike MobileNavbar's
+    // hardcoded tint there's no light-mode-only token here to guard.
+    pathname.current = '/recipes';
+    renderSidebar();
+
+    const accented = document.querySelectorAll(
+      '[data-slot="sidebar-menu-button"][data-active="true"]'
+    );
+    // `asChild` merges the button into the Link, so the accented element is
+    // the anchor itself rather than a wrapper around one.
+    expect(accented).toHaveLength(1);
+    expect(accented[0]).toHaveAttribute('href', '/recipes');
+  });
+
+  it('marks a secondary entry active too', () => {
+    pathname.current = '/privacy-policy';
+    renderSidebar();
+
+    const active = document.querySelectorAll('a[aria-current="page"]');
+    expect(active).toHaveLength(1);
+    expect(active[0]).toHaveAttribute('href', '/privacy-policy');
+  });
+
+  it('carries the shared nav surface treatment on its painted surface', () => {
+    // The same constant MobileNavbar uses, so the two platforms' chrome cannot
+    // drift apart. It has to land on the surface, not the positioning
+    // container, or the surface's own background paints over it.
+    renderSidebar();
+
+    const surface = document.querySelector('[data-slot="sidebar-inner"]');
+    expect(surface).not.toBeNull();
+    for (const className of NAV_SURFACE_CLASS.split(' ')) {
+      expect(surface).toHaveClass(className);
+    }
+  });
+});

--- a/src/test/MobileNavbar.test.tsx
+++ b/src/test/MobileNavbar.test.tsx
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MobileNavbar, {
+  ACTIVE_ACCENT_CLASS,
+} from '@/components/Mobile/MobileNavbar';
+import { NAV_SURFACE_CLASS } from '@/lib/nav-surface';
+
+/**
+ * The mobile bar's contract is a small, fixed item set plus one visibly active
+ * entry, so that's what's asserted here — which hrefs render, and which one
+ * carries the active marker for a given route. Router hooks and `useIsMobile`
+ * are mocked directly rather than wrapped in real providers, following
+ * FeatureInfoModal.test.tsx / IdentifyPanel.test.tsx.
+ */
+
+const { pathname } = vi.hoisted(() => ({ pathname: { current: '/' } }));
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => ({ pathname: pathname.current }),
+  Link: ({
+    to,
+    children,
+    ...props
+  }: {
+    to: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const { isMobile } = vi.hoisted(() => ({ isMobile: { current: true } }));
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => isMobile.current,
+}));
+
+const { offlineEnabled } = vi.hoisted(() => ({
+  offlineEnabled: { current: true },
+}));
+vi.mock('@/lib/feature-flags', () => ({
+  get shouldShowOfflineFeatures() {
+    return offlineEnabled.current;
+  },
+}));
+
+const navLinks = () =>
+  screen.getAllByRole('link').map(link => link.getAttribute('href') ?? '');
+
+const activeLink = () => document.querySelector('a[aria-current="page"]');
+
+beforeEach(() => {
+  pathname.current = '/';
+  isMobile.current = true;
+  offlineEnabled.current = true;
+});
+
+describe('MobileNavbar', () => {
+  it('renders nothing on desktop', () => {
+    isMobile.current = false;
+    render(<MobileNavbar hidden={false} />);
+
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  it('renders only the six entries that fit a small screen', () => {
+    render(<MobileNavbar hidden={false} />);
+
+    // Everything else (instructions, offline maps, legal pages) is reachable
+    // through Settings rather than crowding the bar.
+    expect(navLinks()).toEqual([
+      '/',
+      '/worth-foraging-now',
+      '/recipes',
+      '/species',
+      '/data',
+      '/settings',
+    ]);
+  });
+
+  it('marks the entry for the current route as active', () => {
+    pathname.current = '/species';
+    render(<MobileNavbar hidden={false} />);
+
+    expect(activeLink()).toHaveAttribute('href', '/species');
+  });
+
+  it('gives the active entry the accent tint and no other entry', () => {
+    pathname.current = '/data';
+    render(<MobileNavbar hidden={false} />);
+
+    for (const link of screen.getAllByRole('link')) {
+      const isTarget = link.getAttribute('href') === '/data';
+      for (const className of ACTIVE_ACCENT_CLASS.split(' ')) {
+        // A dark-mode variant is part of the accent, so the light-mode class
+        // alone passing would hide a regression in the other theme.
+        if (isTarget) {
+          expect(link).toHaveClass(className);
+        } else {
+          expect(link).not.toHaveClass(className);
+        }
+      }
+    }
+  });
+
+  it('marks only one entry active at a time', () => {
+    pathname.current = '/recipes';
+    render(<MobileNavbar hidden={false} />);
+
+    expect(document.querySelectorAll('a[aria-current="page"]')).toHaveLength(1);
+  });
+
+  it('keeps Settings active for the sections it rolls up', () => {
+    // The bar has no entry of its own for these, so Settings has to stand in
+    // for them or the user loses their place entirely.
+    for (const route of [
+      '/settings',
+      '/instructions',
+      '/support',
+      '/impressum',
+      '/privacy-policy',
+      '/termsuse',
+      '/offline',
+    ]) {
+      pathname.current = route;
+      const { unmount } = render(<MobileNavbar hidden={false} />);
+
+      expect(activeLink(), route).toHaveAttribute('href', '/settings');
+      unmount();
+    }
+  });
+
+  it('stops rolling Offline Maps up into Settings when the flag is off', () => {
+    // With the flag off the route is unreachable, so Settings claiming it would
+    // be claiming a section that isn't there.
+    offlineEnabled.current = false;
+    pathname.current = '/offline';
+    render(<MobileNavbar hidden={false} />);
+
+    expect(activeLink()).toBeNull();
+  });
+
+  it('carries the shared nav surface treatment', () => {
+    render(<MobileNavbar hidden={false} />);
+
+    const nav = screen.getByRole('navigation');
+    for (const className of NAV_SURFACE_CLASS.split(' ')) {
+      expect(nav).toHaveClass(className);
+    }
+  });
+});

--- a/src/test/nav-surface.test.ts
+++ b/src/test/nav-surface.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { NAV_SURFACE_CLASS } from '@/lib/nav-surface';
+
+/**
+ * `NAV_SURFACE_CLASS` is a string of class names, so nothing in the type system
+ * stops it from naming a utility that doesn't exist — a rename or removal in
+ * `globals.scss` would leave the nav silently unstyled. This test closes that
+ * gap by checking the stylesheet actually defines what the constant names.
+ */
+const globals = readFileSync('src/styles/globals.scss', 'utf8');
+
+// Split first, so an assertion for `elevation-raised` can't be satisfied by
+// `elevation-raised-subtle` sitting in the string instead.
+const classNames = NAV_SURFACE_CLASS.split(' ').filter(Boolean);
+
+describe('NAV_SURFACE_CLASS', () => {
+  it('names only utilities that globals.scss defines', () => {
+    expect(classNames.length).toBeGreaterThan(0);
+    for (const className of classNames) {
+      expect(globals).toMatch(new RegExp(`^\\s*\\.${className}[\\s,{]`, 'm'));
+    }
+  });
+
+  it('is exactly the raised elevation level', () => {
+    // Both nav surfaces are persistent primary nav, so they must not pick up a
+    // dismiss-by-tap-outside or blocking-overlay shadow — nor the quieter
+    // raised-subtle level, which is for input chrome. See CONTEXT.md.
+    expect(classNames).toContain('elevation-raised');
+    expect(classNames).not.toContain('elevation-raised-subtle');
+    expect(classNames).not.toContain('elevation-floating');
+    expect(classNames).not.toContain('elevation-overlay');
+  });
+
+  it('uses exactly the regular glass variant', () => {
+    // Glass-clear is reserved for full-bleed media backgrounds; nav sits over
+    // text content and the map, so it needs the more opaque variant.
+    expect(classNames).toContain('glass-regular');
+    expect(classNames).not.toContain('glass-clear');
+  });
+});


### PR DESCRIPTION
Establishes the elevation/glass/motion design-token layer, then makes the app's
two navigation surfaces the first consumers of it.

Closes #200. Closes #220.

## Why

`AppSidebar` and `MobileNavbar` each hand-rolled their own chrome. The mobile bar
used `bg-card` plus a literal `shadow-[0_2px_16px_rgba(0,0,0,0.10)]`; the sidebar
used `bg-background/95 backdrop-blur`. Nothing tied them together, so the two
platforms' chrome could drift apart, and neither participated in a shared
elevation vocabulary.

## What's here

**Tokens and utilities (#200).** `--elevation-*`, `--glass-*`, `--duration-*` and
`--ease-standard` in `index.css`, with opt-in `.elevation-*` / `.glass-*` utility
classes in `globals.scss`. Glass falls back to opaque under
`prefers-contrast: more` and `prefers-reduced-transparency`, and the shadow scale
carries dark-mode variants. Reconciled against Trailhead in ADR-0001.

**Both nav surfaces adopt them (#220).** `NAV_SURFACE_CLASS` in
`src/lib/nav-surface.ts` is the single place the treatment is named —
`elevation-raised` + `glass-regular` — and both components consume it, so they
can't drift. Raised rather than Floating: that level is reserved for
dismiss-by-tap-outside surfaces, and both of these are persistent primary nav.

## Two things worth a reviewer's attention

**The sidebar's glass was dead code.** `Sidebar`'s `className` lands on the
positioning container, but the painted surface is the inner div, whose opaque
`bg-sidebar` covered it — so `bg-background/95 backdrop-blur` never rendered.
`cn()` alone can't fix it either: `bg-sidebar` and `shadow-sm` are Tailwind
*utilities*-layer classes and outrank the *components*-layer glass utilities.
Hence the new `surfaceClassOverride` prop, which **replaces** shadcn's surface
defaults rather than layering over them, and preserves them when absent. Desktop
rail only — the mobile branch is a Sheet, which is elevation Floating.

Visible consequence: the sidebar's background moves from `--sidebar` (`#f5f3ee`)
to glass-regular's `--card` (`#fdfdfc`), and `#171717` → `#0a0a0a` in dark. That
is the point — it now matches `MobileNavbar` exactly. The mobile bar's own shadow
is pixel-identical, since `--elevation-raised` *is* `0 2px 16px rgba(0,0,0,0.1)`.

**A WCAG 1.4.11 failure this surfaced, now fixed.** `MobileNavbar`'s active tint
hardcoded `--happy-700`, but that scale is light-mode only and never redefined
under `.dark`. Trading opaque `bg-card` for a surface that's 80% opaque in dark
mode lets the map bleed through:

| Dark mode, active nav icon | Contrast |
| --- | --- |
| Before (opaque `bg-card`) | 3.04:1 — scraped past |
| Glass, over a light map, unfixed | 1.72:1 — **fails 3:1** |
| Glass, stepping to `--happy-500` | 5.95:1 |

`AppSidebar` needs no equivalent: its accent rides on
`--sidebar-accent-foreground`, already redefined per theme. Light mode was never
at risk (5.20:1 worst case).

## Smaller notes

- `aria-current='page'` on the active item in both. The active section was
  conveyed by tint and scale alone, with nothing observable to assistive tech.
- `MobileNavbar`'s paint-only wrapper div is gone, with the surface moving to the
  animated nav root: a `backdrop-filter` nested inside a transformed ancestor
  samples the wrong region in Safari.

## Testing

18 new tests across three files — item disclosure per platform and feature flag,
which item carries the accent (asserted against the exported accent constant, not
a copied class string), and a direct unit test guarding `NAV_SURFACE_CLASS`
against naming a utility `globals.scss` no longer defines.

`tsc --noEmit` clean, `eslint --max-warnings 0` clean, `prettier --check` clean,
292 unit tests passing, 81 Storybook browser tests passing.

## Follow-up, not in this PR

Nothing in the app renders a `SidebarTrigger`, so `AppSidebar`'s mobile
off-canvas branch is unreachable in production — mobile navigation goes through
`MobileNavbar` instead. Its mobile item-set logic still exists and is tested by
opening the sheet directly. Worth its own ticket: wire a trigger, or delete the
branch.
