### PR TITLE
Persist rolling weather and score history

### DIFF
--- a/backend/src/funges_backend/db/migrations/versions/0004_weather_scores.py
+++ b/backend/src/funges_backend/db/migrations/versions/0004_weather_scores.py
@@ -1,0 +1,43 @@
+"""Create the rolling weather and score master table.
+
+Revision ID: 0004
+Revises: 0003
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "weather_scores",
+        sa.Column("id", sa.Integer(), autoincrement=True, primary_key=True),
+        sa.Column("region_id", sa.String(length=16), nullable=False),
+        sa.Column("location_id", sa.String(length=160), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("latitude", sa.Float()),
+        sa.Column("longitude", sa.Float()),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("location_id", "date", name="uq_weather_location_date"),
+    )
+    op.create_index("ix_weather_scores_region_date", "weather_scores", ["region_id", "date"])
+    op.create_index("ix_weather_scores_location", "weather_scores", ["location_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_weather_scores_location", table_name="weather_scores")
+    op.drop_index("ix_weather_scores_region_date", table_name="weather_scores")
+    op.drop_table("weather_scores")
+

--- a/backend/src/funges_backend/db/tables.py
+++ b/backend/src/funges_backend/db/tables.py
@@ -5,6 +5,8 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     Column,
+    Date,
+    DateTime,
     Float,
     ForeignKey,
     Integer,
@@ -12,6 +14,7 @@ from sqlalchemy import (
     Table,
     Text,
     UniqueConstraint,
+    func,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
@@ -83,4 +86,18 @@ static_geo_attributes = Table(
     Column("dist_m_sea", Float),
     Column("climate_zone", String(80)),
     Column("ph_level", Float),
+)
+
+weather_scores = Table(
+    "weather_scores",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("region_id", String(16), nullable=False),
+    Column("location_id", String(160), nullable=False),
+    Column("date", Date, nullable=False),
+    Column("latitude", Float),
+    Column("longitude", Float),
+    Column("payload", JSONB, nullable=False),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    UniqueConstraint("location_id", "date", name="uq_weather_location_date"),
 )

--- a/backend/src/funges_backend/repositories/__init__.py
+++ b/backend/src/funges_backend/repositories/__init__.py
@@ -2,6 +2,12 @@
 
 from funges_backend.repositories.geo import BoundaryRepository, CoordinateRepository
 from funges_backend.repositories.species import SpeciesRepository
+from funges_backend.repositories.weather_scores import WeatherScoreRepository
 
-__all__ = ["BoundaryRepository", "CoordinateRepository", "SpeciesRepository"]
+__all__ = [
+    "BoundaryRepository",
+    "CoordinateRepository",
+    "SpeciesRepository",
+    "WeatherScoreRepository",
+]
 

--- a/backend/src/funges_backend/repositories/weather_scores.py
+++ b/backend/src/funges_backend/repositories/weather_scores.py
@@ -1,0 +1,148 @@
+"""Persistence for the rolling weather history and species score master."""
+
+from datetime import date, datetime
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import Engine, select, update
+from sqlalchemy.dialects.postgresql import JSONB, insert
+
+from funges_backend.db.tables import weather_scores
+from funges_backend.forecast_pipeline import assert_window_contiguous
+
+KEY_COLUMNS = {"Location_Id", "Date", "Latitude", "Longitude"}
+
+
+def _json_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, (pd.Timestamp, datetime, date)):
+        return pd.Timestamp(value).isoformat()
+    if bool(pd.isna(value)):
+        return None
+    return value
+
+
+class WeatherScoreRepository:
+    def __init__(self, engine: Engine):
+        self.engine = engine
+
+    def upsert_forecast_rows(self, region_id: str, frame: pd.DataFrame) -> None:
+        """Upsert rows so the later/fresher call wins on overlapping dates."""
+
+        rows = []
+        for record in frame.to_dict(orient="records"):
+            location_id = str(record.get("Location_Id", ""))
+            if not location_id:
+                continue
+            when = pd.Timestamp(record["Date"]).date()
+            rows.append(
+                {
+                    "region_id": region_id,
+                    "location_id": location_id,
+                    "date": when,
+                    "latitude": _json_value(record.get("Latitude")),
+                    "longitude": _json_value(record.get("Longitude")),
+                    "payload": {
+                        key: _json_value(value)
+                        for key, value in record.items()
+                        if key not in KEY_COLUMNS
+                    },
+                }
+            )
+        if not rows:
+            return
+        statement = insert(weather_scores).values(rows)
+        statement = statement.on_conflict_do_update(
+            constraint="uq_weather_location_date",
+            set_={
+                "region_id": statement.excluded.region_id,
+                "latitude": statement.excluded.latitude,
+                "longitude": statement.excluded.longitude,
+                "payload": statement.excluded.payload,
+                "updated_at": pd.Timestamp.now(tz="UTC").to_pydatetime(),
+            },
+        )
+        with self.engine.begin() as connection:
+            connection.execute(statement)
+
+    def read_all(self, region_id: str | None = None) -> pd.DataFrame:
+        query = select(weather_scores).order_by(weather_scores.c.location_id, weather_scores.c.date)
+        if region_id is not None:
+            query = query.where(weather_scores.c.region_id == region_id)
+        with self.engine.connect() as connection:
+            rows = connection.execute(query).mappings().all()
+        return self._to_frame(rows)
+
+    def read_forward_window(self, today: Any, region_id: str | None = None) -> pd.DataFrame:
+        query = select(weather_scores).where(
+            weather_scores.c.date >= pd.Timestamp(today).date()
+        ).order_by(weather_scores.c.location_id, weather_scores.c.date)
+        if region_id is not None:
+            query = query.where(weather_scores.c.region_id == region_id)
+        with self.engine.connect() as connection:
+            rows = connection.execute(query).mappings().all()
+        return self._to_frame(rows)
+
+    def read_location_history(self, location_id: str) -> pd.DataFrame:
+        query = (
+            select(weather_scores)
+            .where(weather_scores.c.location_id == location_id)
+            .order_by(weather_scores.c.date)
+        )
+        with self.engine.connect() as connection:
+            rows = connection.execute(query).mappings().all()
+        return self._to_frame(rows)
+
+    def write_forward_scores(
+        self,
+        frame: pd.DataFrame,
+        *,
+        today: Any,
+        score_columns: list[str],
+    ) -> None:
+        cutoff = pd.Timestamp(today).normalize()
+        forward = frame[pd.to_datetime(frame["Date"]).dt.normalize() >= cutoff]
+        with self.engine.begin() as connection:
+            for record in forward.to_dict(orient="records"):
+                scores = {
+                    column: _json_value(record[column])
+                    for column in score_columns
+                    if column in record
+                }
+                if not scores:
+                    continue
+                connection.execute(
+                    update(weather_scores)
+                    .where(
+                        weather_scores.c.location_id == str(record["Location_Id"]),
+                        weather_scores.c.date == pd.Timestamp(record["Date"]).date(),
+                    )
+                    .values(payload=weather_scores.c.payload.op("||", return_type=JSONB)(scores))
+                )
+
+    def assert_contiguous(self, today: Any, *, region_id: str | None = None) -> None:
+        assert_window_contiguous(self.read_all(region_id), today)
+
+    @staticmethod
+    def _to_frame(rows: list[Any]) -> pd.DataFrame:
+        records = []
+        for row in rows:
+            record = dict(row["payload"])
+            record.update(
+                {
+                    "Location_Id": row["location_id"],
+                    "Date": pd.Timestamp(row["date"]),
+                    "Latitude": row["latitude"],
+                    "Longitude": row["longitude"],
+                }
+            )
+            records.append(record)
+        return pd.DataFrame(records)

--- a/backend/tests/integration/test_weather_score_repository.py
+++ b/backend/tests/integration/test_weather_score_repository.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine
+from testcontainers.community.postgres import PostgresContainer
+
+from funges_backend.forecast_pipeline import apply_forward_scores, merge_master
+from funges_backend.repositories.weather_scores import WeatherScoreRepository
+
+
+@pytest.fixture(scope="module")
+def repository():
+    try:
+        container = PostgresContainer("postgis/postgis:16-3.4")
+        container.start()
+    except Exception as error:
+        pytest.skip(f"Docker/PostGIS is unavailable: {error}")
+
+    backend_root = Path(__file__).resolve().parents[2]
+    url = container.get_connection_url().replace("postgresql+psycopg2", "postgresql+psycopg")
+    config = Config(str(backend_root / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", url)
+    command.upgrade(config, "head")
+    engine = create_engine(url)
+    try:
+        yield WeatherScoreRepository(engine)
+    finally:
+        engine.dispose()
+        container.stop()
+
+
+def fixture_frames():
+    existing = pd.DataFrame(
+        {
+            "Location_Id": ["A", "A"],
+            "Date": pd.to_datetime(["2026-08-24", "2026-08-25"]),
+            "Latitude": [48.0, 48.0],
+            "Longitude": [8.0, 8.0],
+            "Temperature (C)": [10.0, 11.0],
+            "morel_score": [3.0, 4.0],
+        }
+    )
+    fresh = pd.DataFrame(
+        {
+            "Location_Id": ["A", "A"],
+            "Date": pd.to_datetime(["2026-08-25", "2026-08-26"]),
+            "Latitude": [48.0, 48.0],
+            "Longitude": [8.0, 8.0],
+            "Temperature (C)": [12.0, 13.0],
+            "morel_score": [None, None],
+        }
+    )
+    return existing, fresh
+
+
+@pytest.mark.integration
+def test_upsert_matches_keep_last_merge_semantics(repository):
+    existing, fresh = fixture_frames()
+    repository.upsert_forecast_rows("NE", existing)
+    repository.upsert_forecast_rows("NE", fresh)
+
+    expected = merge_master(existing, fresh).sort_values(["Location_Id", "Date"])
+    actual = repository.read_all("NE")
+    columns = ["Location_Id", "Date", "Latitude", "Longitude", "Temperature (C)", "morel_score"]
+    pd.testing.assert_frame_equal(
+        actual[columns].reset_index(drop=True),
+        expected[columns].reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+@pytest.mark.integration
+def test_forward_score_write_preserves_frozen_past(repository):
+    combined = repository.read_all("NE")
+    scored = combined.copy()
+    scored["morel_score"] = [99.0, 7.0, 8.0]
+    today = pd.Timestamp("2026-08-25")
+
+    repository.write_forward_scores(scored, today=today, score_columns=["morel_score"])
+    actual = repository.read_all("NE")
+    expected = apply_forward_scores(
+        combined,
+        scored[pd.to_datetime(scored["Date"]) >= today],
+        ["morel_score"],
+    ).sort_values(["Location_Id", "Date"])
+
+    assert actual.loc[actual["Date"] < today, "morel_score"].tolist() == [3.0]
+    pd.testing.assert_series_equal(
+        actual["morel_score"].reset_index(drop=True),
+        expected["morel_score"].reset_index(drop=True),
+        check_dtype=False,
+        check_names=False,
+    )
+    repository.assert_contiguous(today, region_id="NE")
+


### PR DESCRIPTION
Stack 5/7. Depends on #232. Adds JSONB weather/score persistence, fresh-forecast overlap semantics, frozen history preservation, and contiguity checks.

Closes #138